### PR TITLE
docs: fix list rendering by adding blank lines before lists

### DIFF
--- a/docs/getting-started/getting-started.md
+++ b/docs/getting-started/getting-started.md
@@ -14,14 +14,17 @@ This guide will get your HALPI2 up and running in under 30 minutes and covers pe
 ## What You'll Need
 
 From your HALPI2 package:
+
 - HALPI2 unit with pre-installed CM5 and NVMe SSD
 - Power cable with E7T connector (2m length)
 
 Optional items (included in the sales package):
+
 - DC barrel connector pair (5.5 × 2.1 mm), when using a standard 12V "wall wart" type power supply
 - Raspberry Pi WiFi/Bluetooth antenna (required if WiFi is used for initial setup)
 
 Additional items (not included):
+
 - 12V or 24V power source
 - A separate computer for headless setup (if not using a connected display)
 - Network cable (optional, for wired connection)
@@ -38,6 +41,7 @@ We recommend trying the HALPI2 on a desk or workbench before installing it perma
 ### Step 1: Connect Essential Peripherals
 
 #### For Initial Setup:
+
 1. **Network connection (required for headless installation):**
    - Connect Ethernet cable
    - Connect the WiFi/Bluetooth antenna
@@ -61,6 +65,7 @@ An [NMEA 2000 network](https://docs.hatlabs.fi/nmea2000/) consists of a backbone
     The HALPI2 can also be powered via the NMEA 2000 bus. See [NMEA 2000 Bus Power Connection](#nmea-2000-bus-power-connection) in the Permanent Installation section below.
 
 For the desktop setup, we will use the provided E7T power cable. Connect the power cable wire ends to the female barrel plug as follows:
+
 - **Red wire = Positive (+)**
 - **Black wire = Negative (-)**
 
@@ -152,21 +157,25 @@ The shutdown process typically takes only a few seconds under normal conditions.
 ### Common and Uncommon Issues:
 
 ❌ **No power/LEDs:**
+
 - Verify power connections and polarity
 - Check fuse condition
 - Ensure voltage is within 11-32V range
 
 ❌ **WiFi Access Point not visible:**
+
 - Ensure antenna is properly connected
 - Try to connect using a different device
 - Check if the HALPI2 is fully booted (LEDs should be green)
 - Try connecting via Ethernet first
 
 ❌ **Cannot access the device using `halos.local`:**
+
 - There may be another device on the network with the same hostname
 - Try using the assigned IP address instead (check your router's DHCP client list)
 
 ❌ **Display connected but not showing anything:**
+
 - Ensure HDMI cable is securely connected
 - Ensure the display is powered on and set to the correct input
 - Try a different HDMI cable or port on the display
@@ -174,6 +183,7 @@ The shutdown process typically takes only a few seconds under normal conditions.
 - If the LEDs are flashing in a rainbow pattern, the Compute Module 5 is not properly seated. This may be due to transportation damage. Follow the instructions in the [User Guide](../user-guide/operation.md) to reseat the CM5 or contact support for assistance.
 
 ❌ **Connected display is showing an error message about 'nvme':**
+
 - This indicates the NVMe SSD is not detected or not properly initialized. This can be due to transportation damage. Follow the instructions in the [User Guide](../user-guide/operation.md) to reseat the NVMe SSD or contact support for assistance.
 
 ### Getting Help:
@@ -204,6 +214,7 @@ Take time to plan your installation. Consider:
 #### Required Tools and Materials
 
 **Tools:**
+
 - Drill with bits
 - Screwdriver set (PH2 Phillips, large flathead)
 - Wire strippers and crimpers for power connections
@@ -211,6 +222,7 @@ Take time to plan your installation. Consider:
 - Heat gun or lighter (for heat-shrink tubing)
 
 **Materials (not included):**
+
 - Mounting screws (4mm or M4, depending on the mounting surface)
 - Appropriate fuses (3-5A) or respectively rated electrical panel circuit breakers
 - Marine-grade wire (1.5mm² or 16 AWG for power if the provided cable is too short)
@@ -236,18 +248,21 @@ Even though this guide focuses on fixed installations, in practice it is often s
 #### Environmental Guidelines
 
 **Marine Installations:**
+
 - Mount above expected bilge water level
 - Avoid areas with direct spray or standing water
 - Consider boat movement and vibration, and secure all connections
 - Use corrosion-resistant mounting hardware
 
 **Automotive Installations:**
+
 - Protect from engine heat and vibration
 - Ensure adequate ventilation in enclosed spaces
 - Consider accessibility for maintenance
 - Use vibration-resistant mounting
 
 **Industrial Installations:**
+
 - Protect from process chemicals and extreme temperatures
 - Consider electromagnetic interference sources
 - Ensure compliance with local electrical codes
@@ -297,11 +312,13 @@ Download the [HALPI2 Mounting Template](./HALPI2_enclosure_1B_Drill_Template_v2.
 #### Power Source Selection
 
 **Option 1: Dedicated Power Connector**
+
 - Most reliable and flexible
 - Supports full power capability
 - Easier maintenance and troubleshooting
 
 **Option 2: NMEA 2000 Bus Power**
+
 - Simplifies wiring in marine installations
 - Limited to 0.9A current draw
 - Requires careful attention to voltage drop
@@ -393,12 +410,14 @@ For network connectivity:
 #### Power Problems
 
 ❌ **No power indication:**
+
 - Check fuse condition and rating
 - Verify power source voltage (11-32V)
 - Confirm correct polarity
 - Test continuity of power cables
 
 ❌ **Intermittent power:**
+
 - Check all connection tightness
 - Inspect for corroded terminals
 - Verify adequate wire gauge for current
@@ -406,12 +425,14 @@ For network connectivity:
 #### Network Connectivity
 
 ❌ **No NMEA 2000 communication:**
+
 - Verify network termination (120Ω at both ends)
 - Check T-connector installation
 - Confirm drop cable integrity
 - Test with known-good device
 
 ❌ **No Ethernet connectivity:**
+
 - Test cable with cable tester
 - Verify switch/router configuration
 - Check for IP address conflicts
@@ -420,12 +441,14 @@ For network connectivity:
 #### Environmental Issues
 
 ❌ **Moisture ingress:**
+
 - Inspect all seal conditions
 - Verify connector orientation
 - Check cable entry points
 - Consider additional protection
 
 ❌ **Overheating:**
+
 - Move away from heat sources
 - Check for obstructed airflow around enclosure
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,6 +16,7 @@ The system integrates a Raspberry Pi Compute Module 5 with a custom carrier boar
 ## Key Features and Capabilities
 
 ### Enclosure Features
+
 - **Waterproof (IP65) aluminum enclosure**, size 200×130×60 mm
 - **Standard connectors** for power, NMEA 2000, gigabit ethernet, HDMI, 2× USB 3.0, and WiFi/Bluetooth antenna
 - **Flexible connectivity** with options for 3× PG7 cable glands or SP13 waterproof connectors
@@ -25,6 +26,7 @@ The system integrates a Raspberry Pi Compute Module 5 with a custom carrier boar
 ![HALPI2 Connector Layout](./user-guide/front-panel-connectors-all.jpg)
 
 ### Hardware Features
+
 - **Wide input voltage range** from 10 to 32 VDC with protection up to 100 VDC
 - **Intelligent current limiting**: max input current 0.9 or 2.5 A, user-selectable
 - **Dual power options**: 12V/24V direct connection or 12V NMEA 2000 bus power
@@ -43,6 +45,7 @@ The system integrates a Raspberry Pi Compute Module 5 with a custom carrier boar
 *Interior view of the HALPI2 showing the carrier board and different connectors.*
 
 ### Software Features
+
 - **Pre-configured operating system images** available for immediate deployment: [HaLOS](https://docs.halos.fi) (default), OpenPlotter, Raspberry Pi OS, and Raspberry Pi OS Lite
 - **Comprehensive monitoring** of voltage, current, and temperature
 - **Transparent firmware updates** over I2C interface
@@ -50,6 +53,7 @@ The system integrates a Raspberry Pi Compute Module 5 with a custom carrier boar
 ## Target Applications
 
 ### Marine Applications
+
 - **Navigation systems** with Chart plotters and GPS integration
 - **Data logging** for engine parameters, environmental sensors, and vessel performance
 - **Signal K servers** for unified boat data management
@@ -57,6 +61,7 @@ The system integrates a Raspberry Pi Compute Module 5 with a custom carrier boar
 - **NMEA 2000 network debugging** for improved system reliability
 
 ### Industrial Applications
+
 - **Process monitoring** and control systems
 - **Environmental sensing** and data acquisition
 - **Remote monitoring** stations
@@ -64,6 +69,7 @@ The system integrates a Raspberry Pi Compute Module 5 with a custom carrier boar
 - **Predictive maintenance** systems
 
 ### Automotive Applications
+
 - **Fleet management** systems
 - **Telematics** and vehicle tracking
 - **In-vehicle infotainment** systems
@@ -84,6 +90,7 @@ Your HALPI2 package includes:
 ![HALPI2 Goodie Bag Contents](./goodie-bag-contents.jpg)
 
 Additional accessories available separately:
+
 - **NMEA 2000 drop cable** for bus-powered applications
 - **Various connector kits** for custom installations
 
@@ -92,17 +99,20 @@ Additional accessories available separately:
 This documentation is structured to serve both end users seeking practical guidance and professional developers requiring detailed technical information.
 
 ### For End Users
+
 - Start with the **Getting Started** guide for setup and installation
 - Explore **Common Use Cases** for application-specific guidance
 - Reference **Troubleshooting** when issues arise
 
 ### For Developers
+
 - Review the **Technical Reference** for detailed specifications
 - Study **Software Development** sections for custom applications
 - Examine **Design Files** for integration planning
 - Consult **Advanced Configuration** for performance optimization
 
 ### Documentation Tips
+
 - 💡 **Quick Tips** boxes provide shortcuts for common tasks
 - ⚠️ **Warning** and **Caution** callouts highlight important safety information
 - 🔧 **Technical Details** sections offer in-depth implementation information

--- a/docs/user-guide/operation.md
+++ b/docs/user-guide/operation.md
@@ -65,6 +65,7 @@ Solo mode provides basic autonomous operation when the HALPI daemon is not runni
 The controller monitors input voltage and detects power loss. A blackout timer (default 5 seconds) prevents shutdowns during brief interruptions.
 
 **Automatic Shutdown Sequence:**
+
 1. **Controller detects power loss**
 2. **Blackout timer activates** to distinguish glitches from actual power loss
 3. **Simulated power button presses** - controller sends double power-button presses to Compute Module
@@ -75,6 +76,7 @@ The controller monitors input voltage and detects power loss. A blackout timer (
 8. **Automatic restart** when power is restored
 
 **Manual Shutdown in Solo Mode:**
+
 - Normal operating system shutdown occurs
 - System automatically restarts after 5 seconds if input power remains available
 - For permanent shutdown, disconnect input power after initiating graceful shutdown
@@ -82,6 +84,7 @@ The controller monitors input voltage and detects power loss. A blackout timer (
 #### When Solo Mode is Active
 
 Solo mode occurs:
+
 - During initial boot before HALPI daemon starts
 - If HALPI daemon fails to start or is disabled
 - On unsupported operating systems without the daemon
@@ -108,6 +111,7 @@ Co-op mode provides full power management functionality when the HALPI daemon is
 The controller monitors input power and communicates events directly to the HALPI daemon. The configurable blackout timer (default 5 seconds) allows brief power interruptions without initiating shutdown.
 
 **Automatic Shutdown Sequence:**
+
 1. **Controller detects power loss** and communicates to HALPI daemon
 2. **Blackout timer assessment** - daemon evaluates if power loss exceeds threshold
 3. **Shutdown command execution** - daemon executes shutdown command (default: `/sbin/poweroff`)
@@ -119,6 +123,7 @@ The controller monitors input power and communicates events directly to the HALP
 9. **Restart management** - based on configuration, system restarts automatically or remains off
 
 **Manual Shutdown in Co-op Mode:**
+
 - Standard graceful shutdown occurs when initiated through software
 - System automatically restarts after 5 seconds if input power remains available
 - To prevent automatic restart, disconnect power or configure `auto_restart` to `false`
@@ -135,6 +140,7 @@ Co-op mode includes watchdog timer protection:
 #### When Co-op Mode is Active
 
 Co-op mode occurs when:
+
 - HALPI daemon is running and healthy
 - Communication between daemon and controller is established
 - System operates on a supported operating system
@@ -152,12 +158,14 @@ Co-op mode occurs when:
 Both modes rely on the super-capacitor backup system for graceful shutdown protection:
 
 **Backup Power Duration:**
+
 - Super-capacitors provide 30-60 seconds of backup power
 - Duration depends on system load and connected peripherals
 - Sufficient time for safe file system closure and process termination
 - Not designed for continued operation during extended outages
 
 **Charging Characteristics:**
+
 - Charging time: 25 seconds with 0.9A current limit
 - Charging time: 9 seconds with 2.5A current limit
 - Visual charging progress shown through LED progression (red fill pattern)
@@ -183,11 +191,13 @@ By default, HALPI2 restarts after manual shutdowns when input power remains avai
 For permanent shutdown, use one of these approaches:
 
 **Power Disconnection Method:**
+
 1. Initiate graceful shutdown through software
 2. Wait for shutdown completion (LEDs turn off)
 3. Disconnect input power to prevent automatic restart
 
 **Configuration Method:**
+
 1. Disable automatic restart: `halpi config set auto_restart false`
 2. Initiate shutdown through software
 3. System remains off after shutdown completion


### PR DESCRIPTION
## Summary

Several pages had bullet/numbered lists that immediately followed a paragraph or bold-label intro line with no blank line in between. Python-Markdown (used by MkDocs) folds these items into the preceding paragraph and renders them as inline text rather than a list.

This PR inserts the required blank line before each affected list. No content changes.

## Changes

- `docs/index.md` — 10 lists (after section headings and the "Additional accessories" paragraph)
- `docs/user-guide/operation.md` — 10 lists (after bold-label intros like *Automatic Shutdown Sequence:*, *Backup Power Duration:*, etc.)
- `docs/getting-started/getting-started.md` — 23 lists (mostly after troubleshooting symptom lines and bold-label intros like *Tools:*, *Materials:*, *Marine Installations:*)

## Test plan

- [x] `uv run mkdocs build --strict` passes
- [ ] Spot-check rendered output for the three affected pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)