### PR TITLE
docs(getting-started): motivate CA trust install

### DIFF
--- a/docs/getting-started/getting-started.md
+++ b/docs/getting-started/getting-started.md
@@ -118,8 +118,10 @@ Once connected, open a browser and navigate to:
 - **Dashboard:** `https://halos.local/` — the main Homarr dashboard with links to all installed applications
 - **System administration:** `https://halos.local:9090/` — Cockpit for system management, updates, and container apps
 
-!!! note "SSL Certificate Warning"
-    Your browser will show a certificate warning because HaLOS uses a self-signed certificate. This is expected — accept the warning to proceed.
+!!! note "SSL certificate warning"
+    The first time you open the dashboard or Cockpit, your browser shows a "Not secure" warning. HaLOS signs its web services with a Certificate Authority (CA) it generates on the device itself, and your browser doesn't trust that CA yet. Accept the warning to proceed for now.
+
+    To remove the warning for good, install the device's CA on your computer once — afterwards every HaLOS service validates cleanly on every port. Open `https://halos.local/ca/` for a guided, per-platform installer, or see [Trust the device](https://docs.halos.fi/user-guide/trust-the-device/) in the HaLOS documentation.
 
 !!! info "Internet Required on First Boot"
     The Cockpit interface is available immediately, but the main dashboard and other container-based applications require an internet connection on first boot to download their container images. Connect the HALPI2 to the internet via Ethernet or configure WiFi through Cockpit.


### PR DESCRIPTION
## Why

Part of the device-CA epic: the certificate trust story should be motivated and described in the HALPI2 docs, not just dismissed with "accept the warning." HALPI2 ships HaLOS, so detailed per-platform steps stay in the HaLOS docs and on the device's own `/ca` installer — this just gives the reader the *why* and a pointer.

## What

Expand the getting-started "SSL certificate warning" note:

- Explain that HaLOS signs its web services with a CA generated on the device, which the browser doesn't trust yet — hence the warning.
- Point to the device's guided installer (`https://halos.local/ca/`) and the HaLOS [Trust the device](https://docs.halos.fi/user-guide/trust-the-device/) guide for installing it once.

No platform-specific steps duplicated here. Builds clean under `mkdocs build --strict`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)