### PR TITLE
docs: document UART configuration on HALPI2

### DIFF
--- a/docs/technical-reference/hardware.md
+++ b/docs/technical-reference/hardware.md
@@ -187,7 +187,7 @@ The CAN FD and RS-485 interfaces are galvanically isolated from the rest of the 
 
 | Interface | Signal isolation | Power isolation | Isolated ground |
 |:----------|:-----------------|:---------------|:----------------|
-| CAN FD | ISO7121DR | B0505S-1WR3 | GND_CAN |
+| CAN FD | ISO7721DR | B0505S-1WR3 | GND_CAN |
 | RS-485 | TI41M31 | B0505S-1WR3 | GND_RS485 |
 
 This means bus faults, ground loops and noise on the CAN or RS-485 networks cannot damage or interfere with the main system.

--- a/docs/technical-reference/interfaces.md
+++ b/docs/technical-reference/interfaces.md
@@ -27,12 +27,9 @@ Add the matching `-pi5` overlay to `/boot/firmware/config.txt` and reboot:
 dtoverlay=uart2-pi5
 ```
 
-`uart0` is enabled with `dtparam=uart0=on` instead.
-
-!!! warning "Use the `-pi5` overlays"
-    The plain `uartN` overlays target the legacy Broadcom mini-UART and do
-    nothing useful on a CM5. Always use the `uartN-pi5` form (`uart1-pi5`,
-    `uart2-pi5`, …).
+`uart0` is enabled with `dtparam=uart0=on` instead. (On a CM5 the firmware
+redirects the plain `uartN` overlays to their `uartN-pi5` equivalents, so either
+name works; the `-pi5` form is used here for clarity.)
 
 Hardware flow control is opt-in with the `ctsrts` parameter, and the overlays can
 drive an RS-485 transceiver's enable line directly with the `rs485` parameter:

--- a/docs/technical-reference/interfaces.md
+++ b/docs/technical-reference/interfaces.md
@@ -1,8 +1,89 @@
 # Interfaces and Connectivity
 
+This page documents how the CM5's interfaces are exposed on the HALPI2 carrier
+board. For everyday use of the built-in CAN FD and RS-485 ports, see the
+[Interfaces and Connectivity](../user-guide/interfaces.md) user guide.
+
+## Serial ports (UART)
+
+The Compute Module 5 reaches the 40-pin header through its RP1 I/O controller,
+which exposes five UARTs (`uart0`–`uart4`). Each UART is wired to one fixed GPIO
+pair — unlike earlier Pi models, the pins cannot be remapped. The login console
+is a separate dedicated debug UART (`/dev/ttyAMA10`) and is not one of these.
+
+| UART | TX / RX | Header pins | Linux device | Availability on HALPI2 |
+|:-----|:--------|:------------|:-------------|:-----------------------|
+| `uart0` | GPIO14 / 15 | 8 / 10 | `/dev/ttyAMA0` | Free. Conventional HAT serial port; used for GNSS HATs. |
+| `uart1` | GPIO0 / 1 | 27 / 28 | `/dev/ttyAMA1` | Free. These are the HAT ID EEPROM pins (ID_SD / ID_SC). |
+| `uart2` | GPIO4 / 5 | 7 / 29 | `/dev/ttyAMA2` | Free. |
+| `uart3` | GPIO8 / 9 | 24 / 21 | `/dev/ttyAMA3` | Used by the CAN FD controller (SPI0). |
+| `uart4` | GPIO12 / 13 | 32 / 33 | `/dev/ttyAMA4` | Used by RS-485. |
+
+### Enabling a UART
+
+Add the matching `-pi5` overlay to `/boot/firmware/config.txt` and reboot:
+
+```
+dtoverlay=uart2-pi5
+```
+
+`uart0` is enabled with `dtparam=uart0=on` instead.
+
+!!! warning "Use the `-pi5` overlays"
+    The plain `uartN` overlays target the legacy Broadcom mini-UART and do
+    nothing useful on a CM5. Always use the `uartN-pi5` form (`uart1-pi5`,
+    `uart2-pi5`, …).
+
+Hardware flow control is opt-in with the `ctsrts` parameter, and the overlays can
+drive an RS-485 transceiver's enable line directly with the `rs485` parameter:
+
+```
+dtoverlay=uart2-pi5,ctsrts
+```
+
+CTS/RTS occupy the next GPIO pair, which on HALPI2 is often already in use:
+
+| UART | CTS / RTS | Conflicts with |
+|:-----|:----------|:---------------|
+| `uart1` | GPIO2 / 3 | System I2C bus (I2C1) |
+| `uart2` | GPIO6 / 7 | CAN FD chip-select |
+| `uart3` | GPIO10 / 11 | CAN FD SPI bus |
+| `uart4` | GPIO14 / 15 | `uart0` |
+
+`uart1` is therefore practical only as a TX/RX-only port.
+
+### Freeing an occupied UART
+
+`uart3` and `uart4` overlap the onboard CAN FD and RS-485 interfaces:
+
+- **`uart3`** shares the SPI0 bus with the CAN FD controller — GPIO9 is the
+  controller's data output (SDO). Using `uart3` requires disabling the CAN
+  interface and a hardware modification, and is not supported on the standard
+  board.
+- **`uart4`** is the RS-485 port. Removing the board's RX-enable jumper
+  disconnects the RS-485 receiver from GPIO13, freeing `uart4` for general use.
+  RS-485 is then unavailable.
+
+See [Disabling built-in interfaces](../user-guide/hardware.md#using-hats) for the
+hardware steps.
+
+### Verifying
+
+After rebooting, confirm the device node exists and the pins carry the expected
+function:
+
+```
+ls /dev/ttyAMA*
+pinctrl funcs | grep -iE 'txd|rxd'
+pinctrl 4 5
+```
+
+The selected pins should report their UART function (`a2` for `uart1`–`uart4`,
+`a4` for `uart0`).
+
+## Other topics
+
 - NMEA 2000 implementation details
-- NMEA 0183 (RS-485) configuration
 - USB 3.0 specifications and power management
 - Ethernet and networking
-- GPIO and expansion options
 - M.2 NVMe storage requirements


### PR DESCRIPTION
## Why

The CM5/RP1 UART-to-pin mapping is a common source of confusion, and the technical-reference Interfaces page was an empty placeholder — so there was no single reference for which UARTs are available on HALPI2 and how to enable them.

## What

Fills in `technical-reference/interfaces.md` with a **Serial ports (UART)** section:

- `uart0`–`uart4` mapped to TX/RX GPIO, 40-pin header pins, and `/dev/ttyAMA*` device, with each port's availability on HALPI2.
- Enable instructions using the `-pi5` overlays (with a note that the firmware redirects the plain `uartN` names to the `-pi5` variants on a CM5).
- The `ctsrts`/`rs485` overlay parameters and a CTS/RTS pin-conflict table (uart1→I2C1, uart2→CAN CS, uart3→CAN bus, uart4→uart0).
- How to free `uart3` (shared with CAN FD on SPI0) and `uart4` (RS-485 RX-enable jumper).

All pin assignments verified against a live CM5 (`pinctrl`), the RP1 function table, and the firmware `overlay_map.dtb`; overlay parameters taken from `dtoverlay -h` on-device.

**Fly-by fix:** corrects the CAN isolator part number in `hardware.md` (`ISO7121DR` → `ISO7721DR`).

## Verification

`uv run mkdocs build --strict` passes (no broken links).

🤖 Generated with [Claude Code](https://claude.com/claude-code)