### PR TITLE
Add PDF export to the HALPI2 docs

### DIFF
--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -8,3 +8,12 @@
   <a href="https://github.com/hatlabs/discussions/discussions">Discussion</a>
 </nav>
 {% endblock %}
+
+{% block content %}
+{% if page.url_to_print_page %}
+  <a href="{{ page.url_to_print_page }}" title="Print or save as PDF" class="md-content__button md-icon">
+    {% include ".icons/material/printer.svg" %}
+  </a>
+{% endif %}
+{{ super() }}
+{% endblock %}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -30,6 +30,11 @@ theme:
 
 plugins:
   - search
+  - print-site:
+      add_cover_page: true
+      add_print_site_banner: true
+      add_to_navigation: false
+      print_page_title: HALPI2 User Guide
 
 markdown_extensions:
   - admonition

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,4 +3,7 @@ name = "halpi2-docs"
 version = "0.1.0"
 description = "HALPI2 User Guide documentation"
 requires-python = ">=3.11"
-dependencies = ["mkdocs-material>=9.5"]
+dependencies = [
+    "mkdocs-material>=9.5",
+    "mkdocs-print-site-plugin>=2.8",
+]

--- a/uv.lock
+++ b/uv.lock
@@ -146,10 +146,14 @@ version = "0.1.0"
 source = { virtual = "." }
 dependencies = [
     { name = "mkdocs-material" },
+    { name = "mkdocs-print-site-plugin" },
 ]
 
 [package.metadata]
-requires-dist = [{ name = "mkdocs-material", specifier = ">=9.5" }]
+requires-dist = [
+    { name = "mkdocs-material", specifier = ">=9.5" },
+    { name = "mkdocs-print-site-plugin", specifier = ">=2.8" },
+]
 
 [[package]]
 name = "idna"
@@ -331,6 +335,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/79/9b/9b4c96d6593b2a541e1cb8b34899a6d021d208bb357042823d4d2cabdbe7/mkdocs_material_extensions-1.3.1.tar.gz", hash = "sha256:10c9511cea88f568257f960358a467d12b970e1f7b2c0e5fb2bb48cab1928443", size = 11847, upload-time = "2023-11-22T19:09:45.208Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5b/54/662a4743aa81d9582ee9339d4ffa3c8fd40a4965e033d77b9da9774d3960/mkdocs_material_extensions-1.3.1-py3-none-any.whl", hash = "sha256:adff8b62700b25cb77b53358dad940f3ef973dd6db797907c49e3c2ef3ab4e31", size = 8728, upload-time = "2023-11-22T19:09:43.465Z" },
+]
+
+[[package]]
+name = "mkdocs-print-site-plugin"
+version = "2.8"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mkdocs-material" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a9/18/5c71f48b83191fb30cc58617fea20f56647eaa6cafd06a7fb34c738c5acb/mkdocs_print_site_plugin-2.8.tar.gz", hash = "sha256:ab1c89cdb468352975e3bb3bb0ef25dcc2bb88931b03f173206dc95ab02f843f", size = 231688, upload-time = "2025-08-03T14:15:07.579Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3f/3e/7513f2f37c563da65d1b91781e047f4a1c0ceac8206d4f6042428428e4ad/mkdocs_print_site_plugin-2.8-py3-none-any.whl", hash = "sha256:838bd0a9b7141c11c0f1fdaa51ffe70c35740bec1f07c0806f8018e92f93f9da", size = 21477, upload-time = "2025-08-03T14:15:06.301Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Why

Readers want an offline/printable copy of the HALPI2 User Guide. This adds a one-click path from any page to a PDF.

## How

Uses [mkdocs-print-site-plugin](https://timvink.github.io/mkdocs-print-site-plugin/): a printer icon on every page (top-right, beside the edit pencil) links to a combined `/print_page/` that aggregates the whole guide with a cover page and an auto-numbered TOC. A banner on that page instructs the reader to export via **File > Print > Save as PDF** — the browser renders the PDF, so diagrams and CSS come out exactly as on screen.

Chosen over WeasyPrint-based `mkdocs-with-pdf` (needs apt system libs, and wouldn't render mermaid) and Chromium-based `mkdocs-exporter` (adds a Playwright/Chromium install to CI). This approach adds **no CI dependencies** — `uv sync` picks up the new package and the existing strict build is unchanged.

## Verified

- `uv run mkdocs build --strict` → exit 0, no new warnings
- Printer button renders on every page without colliding with the edit button
- Print page produces cover + banner + full aggregated guide

This is the first of the docs.hatlabs.fi product docs; the same change is being replicated across the others.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
