### PR TITLE
docs(i18n): add Swedish translation

### DIFF
--- a/.claude/skills/translate-page/SKILL.md
+++ b/.claude/skills/translate-page/SKILL.md
@@ -96,7 +96,21 @@ All four, every time:
 uv run mkdocs build --strict
 uv run python scripts/check_anchors.py site
 uv run python scripts/translation_status.py
+uv run python scripts/check_glossary.py fi
 ```
+
+**Measure the glossary, do not reread it.** Rereading your own pages confirms
+whatever they already say, so the terminology looks consistent right up until a
+reviewer finds the same connector under two names on adjacent pages. Every
+language so far shipped that mistake, and each time it landed on the last pages
+translated, once the glossary had stopped being opened. `check_glossary.py`
+reports terms the glossary prescribes and the pages never use — the signature of
+a rival word having quietly taken over.
+
+The same applies to whatever typography rules the glossary sets. Test them
+against the text: count the quotation marks and check they pair, count the
+spaces before `;:!?`, count the address form. A rule that was read looks
+followed.
 
 and a structure comparison against the source:
 

--- a/docs/sv/appendices/compliance.md
+++ b/docs/sv/appendices/compliance.md
@@ -1,3 +1,7 @@
+---
+translated_from: 75cd8c1d6a07b1e062e9cdb4a082d31038fc622c
+---
+
 # Överensstämmelse och certifieringar
 
 - CE-märkning och försäkran om överensstämmelse

--- a/docs/sv/appendices/compliance.md
+++ b/docs/sv/appendices/compliance.md
@@ -1,0 +1,6 @@
+# Överensstämmelse och certifieringar
+
+- CE-märkning och försäkran om överensstämmelse
+- FCC-överensstämmelse
+- Standarder inom båtbranschen
+- Miljöklassningar

--- a/docs/sv/appendices/design-files.md
+++ b/docs/sv/appendices/design-files.md
@@ -1,0 +1,74 @@
+# Konstruktionsfiler och kopplingsscheman
+
+Den här sidan tillhandahåller kopplingsscheman och mekaniska konstruktionsfiler för HALPI2.
+
+HALPI2:s elektronik konstrueras i KiCad. Konstruktionsfilerna finns i [GitHub-repositoriet](https://github.com/hatlabs/HALPI2-hardware). Varje släppt version har en motsvarande tagg i repositoriet.
+
+Kopplingsschemana finns nedan som PDF-filer för enkelhetens skull. Kretskortets layoutfiler finns endast i GitHub-repositoriet.
+
+Mekaniska konstruktionsfiler finns tills vidare bara för kapslingen. Konstruktionen är gjord i Autocad Fusion, men exportfilerna i STEP-format går att öppna i de flesta CAD-program.
+
+## Version 0.6.1
+
+En rättningsversion med förbättringar av signalintegritet och jordning som upptäcktes under produktionstesterna.
+
+Ändringar:
+
+- Klockoscillator tillagd för NVMe SUSCLK, vilket åtgärdar kompatibilitetsproblem med vissa NVMe SSD-enheter
+- Saknade kondensatorer tillagda på USB3-hubbens RX-differentialpar
+- Jordning ordnad vid varje monteringspunkt
+
+### Konstruktionsfiler
+
+- KiCad-konstruktionsfiler: [https://github.com/hatlabs/HALPI2-hardware/archive/refs/tags/v0.6.1.zip](https://github.com/hatlabs/HALPI2-hardware/archive/refs/tags/v0.6.1.zip)
+- Kopplingsschema (PDF): [HALPI2-schematic_v0.6.1.pdf](./HALPI2-schematic_v0.6.1.pdf)
+
+## Version 0.6.0
+
+HALPI2:s tredje produktionsversion med ytterligare mindre rättningar på bärkortet. Kortets funktioner är desamma som i version 0.5.0.
+
+Ändringar:
+
+- 3,3 V-utgången styrs nu av styrkretsen i stället för att alltid vara på
+- Testpunkter tillagda för bättre produktionstester
+- HDMI-, MIPI- och USB3-gränssnitten omdragna för bättre signalintegritet
+- Kortets FFC-anslutningar sitter nu vågrätt
+- Stabiliteten hos 10 V-nedomvandlaren förbättrad — den viner inte längre under några omständigheter
+- Balanseringskretsen för superkondensatorerna omgjord med en enda fyrfaldig operationsförstärkare
+- Vissa komponenters fotavtryck ändrade för bättre tillgänglighet
+
+### Konstruktionsfiler
+
+- KiCad-konstruktionsfiler: [https://github.com/hatlabs/HALPI2-hardware/archive/refs/tags/v0.6.0.zip](https://github.com/hatlabs/HALPI2-hardware/archive/refs/tags/v0.6.0.zip)
+- Kopplingsschema (PDF): [HALPI2-schematic_v0.6.0.pdf](./HALPI2-schematic_v0.6.0.pdf)
+
+## Version 0.5.0
+
+HALPI2:s andra produktionsversion med mindre rättningar på bärkortet. Kortets funktion är densamma som i version 0.4.0.
+
+Ändringar:
+
+- Mindre fel i texttrycket rättade
+- 3,3 V-kopparytor borttagna från undersidan intill monteringsstrukturerna
+- Lödmuttrar tillagda för enklare montering av HAT-kort
+- Lödmuttrar tillagda för säkrare montering av Compute Module
+- Byglarnas stiftlister återförda till hålmontage (THT) för bättre mekanisk hållfasthet
+- Egen +5 V-indikeringslysdiod tillagd
+- Balanseringen av superkondensatorerna mildrad
+- Byglarnas stiftlister omgrupperade för bättre användbarhet
+
+### Konstruktionsfiler
+
+- KiCad-konstruktionsfiler: [https://github.com/hatlabs/HALPI2-hardware/archive/refs/tags/v0.5.0.zip](https://github.com/hatlabs/HALPI2-hardware/archive/refs/tags/v0.5.0.zip)
+- Kopplingsschema (PDF): [HALPI2-schematic_v0.5.0.pdf](./HALPI2-schematic_v0.5.0.pdf)
+- 3D-modell av kapslingen: [HALPI2-enclosure_v0.4.0.step](./HALPI2-enclosure_v0.4.0.step) (samma som i version 0.4.0)
+
+## Version 0.4.0
+
+HALPI2:s första publika version.
+
+### Konstruktionsfiler
+
+- KiCad-konstruktionsfiler: [https://github.com/hatlabs/HALPI2-hardware/archive/refs/tags/v0.4.0.zip](https://github.com/hatlabs/HALPI2-hardware/archive/refs/tags/v0.4.0.zip)
+- Kopplingsschema (PDF): [HALPI2-schematic_v0.4.0.pdf](./HALPI2-schematic_v0.4.0.pdf)
+- 3D-modell av kapslingen: [HALPI2-enclosure_v0.4.0.step](./HALPI2-enclosure_v0.4.0.step)

--- a/docs/sv/appendices/design-files.md
+++ b/docs/sv/appendices/design-files.md
@@ -1,3 +1,7 @@
+---
+translated_from: fc7ea79249b080c0f717303d066b9f6ea6d64795
+---
+
 # Konstruktionsfiler och kopplingsscheman
 
 Den här sidan tillhandahåller kopplingsscheman och mekaniska konstruktionsfiler för HALPI2.

--- a/docs/sv/appendices/errata.md
+++ b/docs/sv/appendices/errata.md
@@ -1,3 +1,7 @@
+---
+translated_from: 930b506809e4abe2b54e4fea058658a9d6d94461
+---
+
 # Kända fel
 
 På den här sidan listas kända hårdvaruproblem i olika versioner av HALPI2.

--- a/docs/sv/appendices/errata.md
+++ b/docs/sv/appendices/errata.md
@@ -1,0 +1,17 @@
+# Kända fel
+
+På den här sidan listas kända hårdvaruproblem i olika versioner av HALPI2.
+
+## Enheter av version 0.4.0
+
+#### Strömtopp vid påslag
+
+När enheten slås på med helt urladdade superkondensatorer kan startströmmen ett kort ögonblick nå 1,1 A. Det gör att enheten nominellt inte uppfyller NMEA 2000-kravet på högst 1 A inström.
+
+Den högre startströmmen beror på ett svårfångat samspel mellan de analoga ingångarna på mikrokontrollern RP2040 och strömbegränsningskretsen.
+
+#### Kopparyta under monteringsklackarna
+
+Ett 3,3 V-spänningsplan på kretskortets undersida sträcker sig ovanför monteringsklackarna. I vissa kapslingar har klackarna kvar vassa gjutgrader (rester av aluminium från gjutningen). Om en grads kant tränger igenom kretskortets lödmask kan den orsaka kortslutning mot 3,3 V-planet och hindra enheten från att starta.
+
+Problemet åtgärdas genom att sätta eltejp av PVC ovanpå monteringsklackarna.

--- a/docs/sv/appendices/resources.md
+++ b/docs/sv/appendices/resources.md
@@ -1,0 +1,7 @@
+# Resurser
+
+- Communityforum och support
+- Kompatibilitet med programvara från tredje part
+- Rekommenderade tillbehör
+- Utbildnings- och kursmaterial
+- Ordlista

--- a/docs/sv/appendices/resources.md
+++ b/docs/sv/appendices/resources.md
@@ -1,3 +1,7 @@
+---
+translated_from: 991d6882660454e7737c452f574d858ffdeb3b93
+---
+
 # Resurser
 
 - Communityforum och support

--- a/docs/sv/faq.md
+++ b/docs/sv/faq.md
@@ -1,0 +1,1 @@
+# Vanliga frågor

--- a/docs/sv/faq.md
+++ b/docs/sv/faq.md
@@ -1,1 +1,5 @@
+---
+translated_from: 4514b4c10652208edff9229b29c132b6f61399f0
+---
+
 # Vanliga frågor

--- a/docs/sv/getting-started/getting-started.md
+++ b/docs/sv/getting-started/getting-started.md
@@ -24,7 +24,7 @@ Ur HALPI2-förpackningen:
 
 Tillval (ingår i försäljningspaketet):
 
-- Par av DC-hylskontakter (5,5 × 2,1 mm), vid användning av en vanlig 12 V-nätadapter
+- Par av DC-hålkontakter (5,5 × 2,1 mm), vid användning av en vanlig 12 V-nätadapter
 - Raspberry Pi WiFi/Bluetooth-antenn (krävs om WiFi används vid den första uppsättningen)
 
 Övrigt (ingår ej):
@@ -68,18 +68,18 @@ Ett [NMEA 2000-nätverk](https://docs.hatlabs.fi/nmea2000/) består av en backbo
 !!! tip "Om matning via NMEA 2000"
     HALPI2 kan även matas från NMEA 2000-bussen. Se [Strömanslutning via NMEA 2000-bussen](#stromanslutning-via-nmea-2000-bussen) i avsnittet om permanent installation nedan.
 
-För uppsättningen på skrivbordet använder vi den medföljande E7T-strömkabeln. Anslut kabelns ledarändar till honhylskontakten så här:
+För uppsättningen på skrivbordet använder vi den medföljande E7T-strömkabeln. Anslut kabelns ledarändar till hålkontakten (hona) så här:
 
 - **Röd ledare = plus (+)**
 - **Svart ledare = minus (-)**
 
-![E7T till hylskontakt](./e7t-barrel.jpg)
-*Ett exempel på kablaget mellan E7T och hylskontakten*
+![E7T till hålkontakt](./e7t-barrel.jpg)
+*Ett exempel på kablaget mellan E7T och hålkontakten*
 
-Anslut en vanlig 12 V- eller 24 V-nätadapter till hylskontakten. Kontrollera att adaptern klarar minst 1 A, vilket HALPI2 kräver.
+Anslut en vanlig 12 V- eller 24 V-nätadapter till hålkontakten. Kontrollera att adaptern klarar minst 1 A, vilket HALPI2 kräver.
 
 !!! warning "Varning"
-    Eftersom skruvplintens hylskontakt saknar dragavlastning bör den bara användas vid tillfälliga installationer. Ett ryck i kabeln kan lossa och blottlägga ledarna.
+    Eftersom skruvplintens hålkontakt saknar dragavlastning bör den bara användas vid tillfälliga installationer. Ett ryck i kabeln kan lossa och blottlägga ledarna.
 
 ## Första start
 
@@ -316,7 +316,7 @@ Hämta [HALPI2:s borrmall](./HALPI2_enclosure_1B_Drill_Template_v2.pdf) och skri
 1. **Rengör monteringsytan**
 2. **Märk ut fästhålen** med den utskrivna mallen
 3. **Provmontera** kapslingen före installationen
-4. **Borra förborrade hål** för monteringsskruvarna
+4. **Förborra hålen** för monteringsskruvarna
 
 ##### Steg 2: Montera HALPI2
 
@@ -350,7 +350,7 @@ Om du vill att starten ska gå fortare, eller behöver mata strömtörstiga krin
 ##### Förbereda kabeln
 
 1. **Dra strömkabeln** från HALPI2 till strömkällan
-2. **Lämna serviceslingor** i båda ändar
+2. **Lämna servicelängor** i båda ändar
 3. **Skydda kabeln** mot skavning och skador
 4. **Kapa till rätt längd** och lämna tillräckligt arbetsutrymme
 
@@ -385,15 +385,15 @@ E7T-kontakten är färdigkopplad och kräver ingen montering på plats. Anslut d
 1. **Stäng av** alla NMEA 2000-enheter
 2. **Öppna HALPI2:s kapsling** (se [Användarguiden](../user-guide/operation.md) för anvisningar)
 3. **Leta upp bärkortets strömkontakt**
-4. **Dra ur den befintliga plinten**
-5. **Anslut den interna NMEA 2000-strömplinten** till bärkortets strömkontakt
+4. **Dra ur den befintliga kopplingsplinten**
+5. **Anslut den interna NMEA 2000-kopplingsplinten för ström** till bärkortets strömkontakt
 6. **Kontrollera att strömbegränsningen** står på 0,9 A
 7. **Anslut till nätverkets backbone** med lämplig stickledning och T-koppling
 8. **Provkör installationen** innan du stänger kapslingen
 9. **Montera ihop kapslingen**
 
 ![Kablage för matning via NMEA 2000](./n2k-power-conx.jpg)
-*För att mata HALPI2 via NMEA 2000, dra ur plint 1 och ersätt den med plint 2.*
+*För att mata HALPI2 via NMEA 2000, dra ur kopplingsplint 1 och ersätt den med kopplingsplint 2.*
 
 ### Nätverks- och dataanslutningar
 
@@ -412,7 +412,7 @@ För nätverksanslutning:
 
 1. **Använd marin** eller på annat sätt miljöklassad kabel
 2. **Montera kabelgenomföringar eller kabelgummin** om kabeln dras genom skott
-3. **Lämna serviceslingor** i båda ändar
+3. **Lämna servicelängor** i båda ändar
 4. **Provkör anslutningen** före den slutliga installationen
 
 #### WiFi/Bluetooth-antenn

--- a/docs/sv/getting-started/getting-started.md
+++ b/docs/sv/getting-started/getting-started.md
@@ -1,0 +1,497 @@
+---
+translated_from: a51e1cfe53d070c073a563641f9301fd3383a418
+---
+
+# Kom igång
+
+Den här guiden får din HALPI2 i gång på under 30 minuter och går även igenom den permanenta installationen. Följ stegen i ordning för smidigast möjliga uppsättning — börja med en uppsättning på skrivbordet för att kontrollera att allt fungerar, och gå sedan vidare till den permanenta installationen.
+
+## Säkerhet och hantering
+
+!!! warning "Innan du börjar"
+    - Se till att strömmen är bortkopplad från elsystemet innan du gör anslutningar
+    - Använd lämpliga säkringar (3–5 A) för strömanslutningar
+    - Hantera enheten varsamt — den är robust, men fall och slag kan skada interna komponenter
+    - Kontrollera polariteten när du ansluter strömkablar
+    - Undvik statiska urladdningar — jorda dig själv och avstå från att gnida katter och bärnstensföremål innan du rör vid interna komponenter
+
+## Det här behöver du
+
+Ur HALPI2-förpackningen:
+
+- HALPI2-enhet med förmonterad CM5 och NVMe SSD
+- Strömkabel med E7T-kontakt (2 m)
+
+Tillval (ingår i försäljningspaketet):
+
+- Par av DC-hylskontakter (5,5 × 2,1 mm), vid användning av en vanlig 12 V-nätadapter
+- Raspberry Pi WiFi/Bluetooth-antenn (krävs om WiFi används vid den första uppsättningen)
+
+Övrigt (ingår ej):
+
+- 12 V- eller 24 V-strömkälla
+- En separat dator för uppsättning utan skärm (om du inte ansluter en skärm)
+- Nätverkskabel (valfritt, för trådbunden anslutning)
+- Skärm med HDMI-ingång (valfritt)
+- USB-tangentbord och mus (valfritt, för direkt åtkomst)
+
+!!! tip "Snabbtips"
+    Nätverksutrustning som routrar och WiFi-accesspunkter använder ofta en 12 V-nätadapter som går att använda till HALPI2. Leta i högen med gammal hårdvara!
+
+## Uppsättning på skrivbordet
+
+Vi rekommenderar att du provar HALPI2 på ett skrivbord eller en arbetsbänk innan du installerar den permanent. Den första uppsättningen kan göras antingen utan skärm (headless) över en nätverksanslutning, eller med ansluten skärm, tangentbord och mus. En uppsättning utan skärm kan använda antingen trådbunden ethernet eller HALPI2:s WiFi-accesspunkt.
+
+### Steg 1: Anslut nödvändiga kringenheter
+
+#### För den första uppsättningen:
+
+1. **Nätverksanslutning (krävs vid installation utan skärm):**
+    - Anslut en ethernetkabel
+    - Anslut WiFi/Bluetooth-antennen
+
+2. **Skärmanslutning (valfritt):**
+    - Anslut en HDMI-skärm för direkt åtkomst
+    - USB-tangentbord och mus om du använder skärm
+
+![Frontpanelens kontakter](./front-panel-connectors.jpg)
+*Frontpanelens kontakter*
+
+### Steg 2: NMEA 2000-anslutning (valfritt)
+
+Om du installerar HALPI2 direkt i en båt eller har en NMEA 2000-installation på skrivbordet kan du ansluta enheten till NMEA 2000-nätverket redan nu.
+
+Ett [NMEA 2000-nätverk](https://docs.hatlabs.fi/nmea2000/) består av en backbone-kabel som alla enheter ansluts till med T-kopplingar och stickledningar. Sätt en T-koppling på nätverkets backbone. Anslut HALPI2:s Micro-C-kontakt till T-kopplingen med en NMEA 2000-stickledning.
+
+### Steg 3: Strömanslutning
+
+!!! tip "Om matning via NMEA 2000"
+    HALPI2 kan även matas från NMEA 2000-bussen. Se [Strömanslutning via NMEA 2000-bussen](#stromanslutning-via-nmea-2000-bussen) i avsnittet om permanent installation nedan.
+
+För uppsättningen på skrivbordet använder vi den medföljande E7T-strömkabeln. Anslut kabelns ledarändar till honhylskontakten så här:
+
+- **Röd ledare = plus (+)**
+- **Svart ledare = minus (-)**
+
+![E7T till hylskontakt](./e7t-barrel.jpg)
+*Ett exempel på kablaget mellan E7T och hylskontakten*
+
+Anslut en vanlig 12 V- eller 24 V-nätadapter till hylskontakten. Kontrollera att adaptern klarar minst 1 A, vilket HALPI2 kräver.
+
+!!! warning "Varning"
+    Eftersom skruvplintens hylskontakt saknar dragavlastning bör den bara användas vid tillfälliga installationer. Ett ryck i kabeln kan lossa och blottlägga ledarna.
+
+## Första start
+
+HALPI2 levereras med [HaLOS](https://docs.halos.fi), en containerbaserad Linux-distribution med webbaserat gränssnitt, avsedd för marina och industriella tillämpningar. Om du föredrar ett annat operativsystem, som OpenPlotter eller Raspberry Pi OS, se [Programvaruguiden](../user-guide/software.md).
+
+!!! info "HaLOS dokumentation"
+    Den här guiden behandlar HALPI2:s hårdvara och den första påslagningen. Allt som rör operativsystemet — uppsättning vid första start, nätverk, appar, certifikat och den dagliga användningen — finns i **[HaLOS dokumentation](https://docs.halos.fi)**. Ha den till hands när du går igenom stegen nedan.
+
+**Slå på HALPI2** genom att ansluta nätadaptern, om du inte redan gjort det. Efter några sekunder börjar LED-raden fyllas med rött ljus, vilket visar att superkondensatorerna laddas. Lysdioderna blir gula när systemet startar och slutligen gröna när operativsystemet körs och HALPI-daemonen har kontakt med styrkretsen.
+
+Om du har en skärm ansluten ser du Raspberry Pi OS startbild och till sist ett grafiskt skrivbord.
+
+!!! tip "Tips"
+    Statuslysdiodernas mönster beskrivs i [Systemdrift](../user-guide/operation.md).
+
+### Åtkomst till HALPI2 utan skärm
+
+Om du inte har någon skärm ansluten når du HALPI2 via dess WiFi-accesspunkt eller en ethernetanslutning. HaLOS har ett webbaserat gränssnitt — ingen ytterligare programvara behövs[^ssh].
+
+[^ssh]: SSH finns också på HaLOS-avbilder utan skärm (aktiverat som standard). I Desktop-varianterna aktiverar du SSH med `raspi-config`. Standarduppgifter: användarnamn `pi`, lösenord `halos`.
+
+Vänta först tills lysdioderna blir gröna, vilket betyder att systemet har startat färdigt. Fortsätt sedan så här:
+
+**Alternativ 1 — anslutning via WiFi-accesspunkten:** HaLOS skapar en WiFi-accesspunkt med namnet `Halos-XXXX` (unikt per enhet) och lösenordet `halos1234`. Anslut din dator till det nätverket.
+
+Accesspunkten har ingen egen internetanslutning, så nästa steg är att peka ut ett WiFi-nätverk som har det (behövs för att hämta containerapparna vid första start):
+
+1. Öppna Cockpit på `https://halos.local:9090/` och logga in (användarnamn `pi`, lösenord `halos`).
+2. Gå till **Networking** och klicka på **WiFi (wlan0)**.
+3. Vänta tills listan över tillgängliga nätverk visas och klicka på ditt nätverk.
+4. Ange lösenordet och klicka på **Add**.
+
+HALPI2 håller accesspunkten `Halos-XXXX` uppe medan den ansluter till ditt nätverk, så din dator kan tappa kontakten med accesspunkten en kort stund och sedan ansluta igen av sig själv.
+
+**Alternativ 2 — anslutning via trådbunden ethernet:** om du har anslutit HALPI2 till ditt nätverk med ethernet får den automatiskt en IP-adress via DHCP.
+
+När anslutningen är på plats öppnar du en webbläsare och går till:
+
+- **Instrumentpanel:** `https://halos.local/` — Homarr-instrumentpanelen med länkar till alla installerade appar
+- **Systemadministration:** `https://halos.local:9090/` — Cockpit för systemhantering, uppdateringar och containerappar
+
+!!! note "Varning om SSL-certifikat"
+    Första gången du öppnar instrumentpanelen eller Cockpit visar webbläsaren varningen ”Inte säker”. HaLOS signerar sina webbtjänster med en certifikatutfärdare (CA) som enheten själv skapar, och din webbläsare litar inte på den ännu. Godta varningen för att fortsätta tills vidare.
+
+    För att bli av med varningen permanent installerar du enhetens CA på din dator en gång — därefter validerar alla HaLOS-tjänster rent på alla portar. Öppna `https://halos.local/ca/` för ett guidat installationsprogram per plattform, eller se [Trust the device](https://docs.halos.fi/user-guide/trust-the-device/) i HaLOS dokumentation.
+
+!!! info "Internet krävs vid första start"
+    Cockpit-gränssnittet är tillgängligt direkt, men instrumentpanelen och övriga containerbaserade appar kräver en internetanslutning vid första start för att hämta sina containeravbilder. Anslut HALPI2 till internet via ethernet, eller konfigurera WiFi via Cockpit.
+
+### Konfiguration vid första start
+
+!!! warning "Varning"
+    HaLOS levereras med standardlösenord som **måste** bytas vid första start, för att hindra obehörig åtkomst till din enhet.
+
+HaLOS har två uppsättningar inloggningsuppgifter:
+
+| Typ av åtkomst | Användarnamn | Standardlösenord | Används till |
+|:---------------|:-------------|:-----------------|:-------------|
+| SSO (webbappar) | `admin` | `halos` | Instrumentpanelen, Signal K, Grafana och andra webbappar |
+| System (SSH/Cockpit) | `pi` | `halos` | SSH-åtkomst, systemadministration i Cockpit |
+
+#### Att byta lösenord
+
+- **SSO-lösenordet:** byts via Authelia (nås från instrumentpanelen)
+- **Systemlösenordet:** byts via Cockpit (`https://halos.local:9090/`) under användarkontots inställningar, eller via SSH med `passwd`
+
+Utförliga anvisningar för första start finns i [HaLOS guide Kom igång](https://docs.halos.fi/getting-started/first-boot/).
+
+!!! info "Använder du OpenPlotter eller Raspberry Pi OS?"
+    Om du har flashat ett annat operativsystem, se [Programvaruguiden](../user-guide/software.md#forsta-konfigurationen-av-systemet) för operativsystemsspecifika anvisningar.
+
+### Kontrollera NMEA 2000-anslutningen (valfritt)
+
+Enklast kontrollerar du NMEA 2000-anslutningen genom att titta på Signal K-serverns status. I HaLOS Marine-avbilderna är Signal K förinstallerad och nås från instrumentpanelen på `https://halos.local/`. I HaLOS-avbilder som inte är marina kan Signal K installeras från Container Apps-butiken i Cockpit.
+
+Öppna Signal K:s webbgränssnitt och titta på aktiviteten för anslutningen `can0`: du bör se att en del trafik tas emot.
+
+![Anslutningsaktivitet i Signal K-servern](./sk-n2k-deltas.jpg)
+
+## Att stänga av enheten
+
+HALPI2 är konstruerad för att stänga av sig automatiskt när strömförsörjningen bryts. När du behöver stänga av enheten bryter du helt enkelt strömmen, antingen med en brytare på elpanelen eller genom att dra ur strömkontakten. Systemet påbörjar då automatiskt en avstängning i programvaran, så att alla program stängs korrekt och filsystemet avmonteras säkert.
+
+Om du väljer att stänga av systemet från skrivbordet eller med kommandoradsverktyg (som kommandot `shutdown`) startar enheten om automatiskt efter ungefär 5 sekunder. Det beror på att strömhanteringen märker att den externa strömmen fortfarande finns.
+
+Under avstängningen kan du följa systemets tillstånd på frontpanelens lysdioder. När strömmen först bryts dämpas de gröna lysdioderna för att visa ett spänningsbortfall. Efter 5 sekunder blir de violetta, vilket tydligt visar att enheten håller på att stängas av. När avstängningen är klar släcks alla lysdioder.
+
+Avstängningen tar normalt bara några sekunder. I vissa fall kan enskilda tjänster dock behöva mer tid för att stoppas ordentligt. Då kan enheten tömma superkondensatorerna nästan helt innan den stängs av. Den längre avstängningstiden är normal och betyder inte att något är fel.
+
+## Felsökning vid uppstart
+
+### Vanliga och ovanliga problem:
+
+❌ **Ingen ström / inga lysdioder:**
+
+- Kontrollera strömanslutningarna och polariteten
+- Kontrollera säkringen
+- Se till att spänningen ligger inom 11–32 V
+
+❌ **WiFi-accesspunkten syns inte:**
+
+- Se till att antennen är ordentligt ansluten
+- Prova att ansluta med en annan enhet
+- Kontrollera att HALPI2 har startat färdigt (lysdioderna ska vara gröna)
+- Prova att ansluta via ethernet först
+
+❌ **Enheten går inte att nå på `halos.local`:**
+
+- Prova den tilldelade IP-adressen i stället (se routerns lista över DHCP-klienter)
+
+❌ **Skärmen är ansluten men visar ingenting:**
+
+- Se till att HDMI-kabeln sitter ordentligt
+- Se till att skärmen är påslagen och står på rätt ingång
+- Prova en annan HDMI-kabel eller en annan port på skärmen
+- Kontrollera att HALPI2 är på (lysdioderna ska vara gula eller gröna)
+- Om lysdioderna blinkar i ett regnbågsmönster sitter Compute Module 5 inte ordentligt. Det kan bero på transportskada. Följ anvisningarna i [Användarguiden](../user-guide/operation.md) för att sätta tillbaka CM5, eller kontakta supporten.
+
+❌ **Den anslutna skärmen visar ett felmeddelande om ”nvme”:**
+
+- Det betyder att NVMe SSD-enheten inte hittas eller inte initieras korrekt. Det kan bero på transportskada. Följ anvisningarna i [Användarguiden](../user-guide/operation.md) för att sätta tillbaka SSD-enheten, eller kontakta supporten.
+
+### Att få hjälp:
+
+- **Dokumentation:** se de enskilda avsnitten för utförlig felsökning
+- **Gemenskapen:** gå med i Hat Labs diskussionsforum
+- **Support:** kontakta den tekniska supporten vid hårdvaruproblem
+
+---
+
+## Permanent installation
+
+När du har kontrollerat att allt fungerar på skrivbordet följer du de här stegen för permanent montering och kablage.
+
+### Att planera installationen
+
+!!! tip "Snabbtips"
+    Ta foton av det befintliga kablaget innan du ändrar något — det hjälper vid senare felsökning.
+
+Ta dig tid att planera installationen. Tänk på:
+
+- **Monteringsplats** — åtkomlighet, skydd, ventilation
+- **Kabeldragning** — kortast möjliga sträckor, skydd mot skador
+- **Strömkälla** — egen krets eller delad, krav på säkring
+- **Nätverksintegration** — NMEA 2000, ethernet, WiFi-täckning
+- **Miljöfaktorer** — temperatur, fukt, vibrationer
+
+#### Verktyg och material som behövs
+
+**Verktyg:**
+
+- Borrmaskin med borr
+- Skruvmejselsats (PH2 Phillips, stor spårmejsel)
+- Avisoleringstång och krimptång för strömanslutningarna
+- Multimeter för mätning
+- Varmluftspistol eller tändare (för krympslang)
+
+**Material (ingår ej):**
+
+- Monteringsskruvar (4 mm eller M4, beroende på monteringsytan)
+- Lämpliga säkringar (3–5 A) eller automatsäkringar med motsvarande märkning på elpanelen
+- Marin kabel (1,5 mm² eller 16 AWG för matningen, om den medföljande kabeln är för kort)
+- Krympslang och kabelskor
+- Buntband och kabelklamrar
+
+### Montering
+
+#### Val av plats
+
+Välj en monteringsplats som ger:
+
+!!! tip "Optimala monteringsförhållanden"
+    - **Temperaturområde:** -20 °C till +60 °C omgivningstemperatur
+    - **Ventilation:** tillräckligt fritt utrymme runt kapslingen
+    - **Skydd:** undan direkt vattenstänk och mekaniska skador
+    - **Åtkomst:** lätt att nå kontakter och statuslysdioder
+    - **Bärighet:** ett stadigt underlag som bär 2 kg plus kablar
+    - **Utrymme:** minst 100 mm fritt framför panelkontakterna för kabeldragningen
+
+Även om den här guiden inriktar sig på fasta installationer räcker det i praktiken ofta att ställa enheten på en hylla eller ett bord, förutsatt att den står stadigt och är skyddad mot fukt och slag.
+
+#### Riktlinjer för miljön
+
+**Marina installationer:**
+
+- Montera ovanför förväntad nivå för slagvatten
+- Undvik ytor med direkt stänk eller stående vatten
+- Ta hänsyn till båtens rörelser och vibrationer, och säkra alla anslutningar
+- Använd korrosionsbeständiga infästningar
+
+**Fordonsinstallationer:**
+
+- Skydda mot motorvärme och vibrationer
+- Se till att ventilationen räcker i slutna utrymmen
+- Tänk på åtkomsten vid underhåll
+- Använd vibrationståliga infästningar
+
+**Industriella installationer:**
+
+- Skydda mot processkemikalier och extrema temperaturer
+- Tänk på källor till elektromagnetiska störningar
+- Se till att lokala elföreskrifter följs
+- Planera för åtkomst vid rutinunderhåll
+
+#### Monteringsriktning
+
+!!! info "Rekommenderad riktning"
+    **Att föredra:** kontakterna nedåt
+
+    - Minskar risken för vatteninträngning
+    - Ger snyggare kabeldragning
+    - Enklare åtkomst vid underhåll
+
+    **Godtagbart:** kontakterna åt sidan
+
+    - Se till att vatten kan rinna av
+    - Använd tätningar vid kabelinföringarna
+
+    **Undvik:** kontakterna uppåt
+
+    - Ökar risken för vatteninträngning
+    - Försvårar kabeldragningen
+
+#### Monteringssteg
+
+##### Steg 0: Hämta och skriv ut borrmallen
+
+Hämta [HALPI2:s borrmall](./HALPI2_enclosure_1B_Drill_Template_v2.pdf) och skriv ut den i skala 100 %. Med mallen märker du ut fästhålen exakt. Om du inte har tillgång till en skrivare kan du i stället använda måtten i mallen för att märka ut hålen för hand, eller använda själva kapslingen för att märka ut dem direkt på underlaget.
+
+[![Borrmall](./HALPI2_enclosure_1B_Drill_Template_v2.png)](./HALPI2_enclosure_1B_Drill_Template_v2.pdf)
+
+##### Steg 1: Förbered monteringsytan
+
+1. **Rengör monteringsytan**
+2. **Märk ut fästhålen** med den utskrivna mallen
+3. **Provmontera** kapslingen före installationen
+4. **Borra förborrade hål** för monteringsskruvarna
+
+##### Steg 2: Montera HALPI2
+
+1. **Placera kapslingen** med kontakterna i önskad riktning
+2. **Dra i monteringsskruvarna** — stadigt men utan att dra åt för hårt
+
+### Permanent strömanslutning
+
+#### Val av strömkälla
+
+**Alternativ 1: egen strömkontakt**
+
+- Mest tillförlitligt och flexibelt
+- Ger full effektkapacitet
+- Enklare underhåll och felsökning
+
+**Alternativ 2: matning från NMEA 2000-bussen**
+
+- Förenklar kablaget i marina installationer
+- Begränsad till 0,9 A strömuttag
+- Kräver noggrann uppmärksamhet på spänningsfallet
+
+#### Konfiguration av strömbegränsningen
+
+HALPI2 har en inbyggd strömbegränsare på ingången som sköter den inledande laddningen av superkondensatorerna och skyddar installationen mot överström. Begränsningen kan ställas till antingen 0,9 A eller 2,5 A, beroende på strömkälla och tillämpningens krav. Standardinställningen 0,9 A passar de flesta tillämpningar.
+
+Om du vill att starten ska gå fortare, eller behöver mata strömtörstiga kringenheter, kan du byta till inställningen 2,5 A. Följ stegen i [Användarguiden](../user-guide/operation.md) för att ändra strömbegränsningen.
+
+#### Egen strömanslutning
+
+##### Förbereda kabeln
+
+1. **Dra strömkabeln** från HALPI2 till strömkällan
+2. **Lämna serviceslingor** i båda ändar
+3. **Skydda kabeln** mot skavning och skador
+4. **Kapa till rätt längd** och lämna tillräckligt arbetsutrymme
+
+##### Anslutning vid strömkällan
+
+1. **Skydda ledningen** genom att avsätta en automatsäkring på 3–5 A eller montera en säkring i serie
+2. **Avisolera ledarändarna** till lämplig längd
+3. **Montera kabelskor** med rätt krimpteknik
+4. **Anslut till strömkällan:**
+    - **Röd ledare:** plusanslutning (+)
+    - **Svart ledare:** minusanslutning (-)
+5. **Kontrollera polariteten** med multimeter innan du kopplar på spänningen
+
+##### Anslutning vid HALPI2
+
+E7T-kontakten är färdigkopplad och kräver ingen montering på plats. Anslut den bara till HALPI2:s strömuttag.
+
+#### Strömanslutning via NMEA 2000-bussen
+
+!!! info "Förutsättningar"
+    - Omkopplaren för strömbegränsning **måste** stå på 0,9 A
+    - NMEA 2000-nätverket måste ha tillräcklig effektkapacitet
+    - Stickledningen bör sitta nära matningspunkten för att minska spänningsfallet
+
+##### Komponenter som behövs
+
+- NMEA 2000-stickledning (ingår ej)
+- T-koppling för anslutning till backbone (ingår ej)
+
+##### Installationssteg
+
+1. **Stäng av** alla NMEA 2000-enheter
+2. **Öppna HALPI2:s kapsling** (se [Användarguiden](../user-guide/operation.md) för anvisningar)
+3. **Leta upp bärkortets strömkontakt**
+4. **Dra ur den befintliga plinten**
+5. **Anslut den interna NMEA 2000-strömplinten** till bärkortets strömkontakt
+6. **Kontrollera att strömbegränsningen** står på 0,9 A
+7. **Anslut till nätverkets backbone** med lämplig stickledning och T-koppling
+8. **Provkör installationen** innan du stänger kapslingen
+9. **Montera ihop kapslingen**
+
+![Kablage för matning via NMEA 2000](./n2k-power-conx.jpg)
+*För att mata HALPI2 via NMEA 2000, dra ur plint 1 och ersätt den med plint 2.*
+
+### Nätverks- och dataanslutningar
+
+#### NMEA 2000-dataanslutning
+
+Även med en egen strömanslutning kan du vilja ha NMEA 2000-data:
+
+1. **Montera en T-koppling** på NMEA 2000-nätverkets backbone
+2. **Anslut en stickledning** mellan T-kopplingen och HALPI2
+3. **Kontrollera termineringen** av NMEA 2000-nätverket
+4. **Provkör anslutningen** efter installationen
+
+#### Ethernetanslutning
+
+För nätverksanslutning:
+
+1. **Använd marin** eller på annat sätt miljöklassad kabel
+2. **Montera kabelgenomföringar eller kabelgummin** om kabeln dras genom skott
+3. **Lämna serviceslingor** i båda ändar
+4. **Provkör anslutningen** före den slutliga installationen
+
+#### WiFi/Bluetooth-antenn
+
+1. **Montera antennen** på RP-SMA-kontakten
+2. **Placera den för bästa täckning** — undan metallhinder. I metallskåp kan en förlängningskabel med RP-SMA hane till hona behövas.
+3. **Mät signalstyrkan** i den slutliga placeringen
+
+### Felsökning vid installation
+
+#### Strömproblem
+
+❌ **Ingen strömindikering:**
+
+- Kontrollera säkringens skick och märkning
+- Kontrollera strömkällans spänning (11–32 V)
+- Bekräfta rätt polaritet
+- Mät genomgången i strömkablarna
+
+❌ **Glappande ström:**
+
+- Kontrollera att alla anslutningar sitter åt
+- Leta efter korroderade anslutningar
+- Kontrollera att ledararean räcker för strömmen
+
+#### Nätverksanslutning
+
+❌ **Ingen NMEA 2000-kommunikation:**
+
+- Kontrollera nätverkets terminering (120 Ω i båda ändar)
+- Kontrollera T-kopplingens montering
+- Kontrollera stickledningens skick
+- Prova med en enhet som du vet fungerar
+
+❌ **Ingen ethernetanslutning:**
+
+- Testa kabeln med en kabeltestare
+- Kontrollera switchens eller routerns konfiguration
+- Leta efter IP-adresskonflikter
+- Kontrollera kabelns klassning (minst Cat5e)
+
+#### Miljöproblem
+
+❌ **Fuktinträngning:**
+
+- Kontrollera alla tätningar
+- Kontrollera kontakternas riktning
+- Kontrollera kabelinföringarna
+- Överväg ytterligare skydd
+
+❌ **Överhettning:**
+
+- Flytta enheten bort från värmekällor
+- Kontrollera att luftflödet runt kapslingen inte är blockerat
+
+### Säkerhet och regelefterlevnad
+
+#### Elsäkerhet
+
+- **Använd lämpliga säkringar** som överströmsskydd
+- **Se till att jordningen är korrekt** enligt lokala föreskrifter
+- **Skydda mot kortslutning** med genomtänkt kabeldragning
+
+#### Marina installationer
+
+- **Följ lokala standarder eller ABYC** för elinstallationer
+- **Använd marina komponenter** genomgående
+
+#### Industriella installationer
+
+- **Följ lokala elföreskrifter**
+- **Se till att EMI/RFI-skyddet** är tillräckligt
+- **Dokumentera installationen** enligt anläggningens krav
+
+## Nästa steg
+
+När din HALPI2 är i gång:
+
+1. **Läs [Användarguiden](../user-guide/operation.md)** för utförliga driftanvisningar
+2. **Gå igenom vanliga användningsfall** för uppsättningar som passar din tillämpning
+3. **Titta i den tekniska referensen** för avancerade konfigurationsmöjligheter
+4. **Gå med i gemenskapen** för tips, knep och stöd

--- a/docs/sv/index.md
+++ b/docs/sv/index.md
@@ -1,3 +1,7 @@
+---
+translated_from: e4d4a4c5108676be9c19bdd2a82a321b24b14191
+---
+
 # Introduktion
 
 HALPI2 är en färdig båtdator baserad på Raspberry Pi Compute Module 5 (CM5). Den har ett brett funktionsutbud som passar väl för marina tillämpningar, fordonstillämpningar och många industriella användningsområden.

--- a/docs/sv/index.md
+++ b/docs/sv/index.md
@@ -1,0 +1,121 @@
+# Introduktion
+
+HALPI2 är en färdig båtdator baserad på Raspberry Pi Compute Module 5 (CM5). Den har ett brett funktionsutbud som passar väl för marina tillämpningar, fordonstillämpningar och många industriella användningsområden.
+
+![HALPI2](./halpi2_front_view.jpg)
+
+!!! note "Länk till butiken"
+    Köp HALPI2 i [Hat Labs webbutik](https://shop.hatlabs.fi/products/halpi2-computer).
+
+## Vad är HALPI2?
+
+HALPI2 är den senaste utvecklingen inom tålig inbyggd datorteknik: den förenar Raspberry Pi:s prestanda och ekosystem med funktioner för krävande miljöer. Till skillnad från vanliga enkortsdatorer är HALPI2 konstruerad från grunden för kontinuerlig drift under svåra förhållanden, där tillförlitlighet är avgörande.
+
+Systemet kombinerar en Raspberry Pi Compute Module 5 med ett specialkonstruerat bärkort, allt inbyggt i en vattentät aluminiumkapsling som samtidigt fungerar som kylfläns. Konstruktionen ger den beräkningskraft moderna tillämpningar kräver och behåller samtidigt den tålighet som marin och industriell användning förutsätter.
+
+## Viktigaste egenskaper
+
+### Kapslingens egenskaper
+
+- **Vattentät aluminiumkapsling (IP65)**, mått 200 × 130 × 60 mm
+- **Standardanslutningar** för strömförsörjning, NMEA 2000, gigabit-ethernet, HDMI, 2× USB 3.0 och WiFi-/Bluetooth-antenn
+- **Flexibla anslutningsalternativ**: 3× PG7-kabelgenomföring eller vattentäta SP13-kontakter
+- **Stöd för externa antenner**: uttag för 2 extra SMA-kontakter
+- **Konstruerad för väggmontage**, med anslutningarna placerade för enkel installation
+
+![HALPI2:s anslutningar](./user-guide/front-panel-connectors-all.jpg)
+
+### Hårdvarans egenskaper
+
+- **Brett inspänningsområde** från 10 till 32 V DC, med skydd upp till 100 V DC
+- **Intelligent strömbegränsning**: maximal inström 0,9 eller 2,5 A, valbart av användaren
+- **Två sätt att mata ström**: direkt anslutning med 12 V/24 V, eller matning från NMEA 2000-bussen med 12 V
+- **Backup med superkondensatorer** för störningstålighet och kontrollerad avstängning vid spänningsbortfall
+- **Avancerad strömhantering** med automatisk detektering av spänningsbortfall
+- **Passiv kylning**: CM5 har direkt kontakt med kapslingen
+- **Snabb lagring** via ett vanligt M.2 NVMe SSD-gränssnitt
+- **Utbyggbarhet** via Raspberry Pi:s 40-poliga GPIO-stiftlist
+- **Rikligt med in- och utgångar**: 2× HDMI, 2× MIPI (DSI/CSI), 4× USB 3.0, gigabit-ethernet
+- **Gränssnitt för marint bruk**: CAN FD (NMEA 2000) och RS-485 (NMEA 0183)
+- **Realtidsklocka** med backupbatteri för korrekt tid
+- **Synlig statusindikering** via fem RGB-lysdioder
+- **Användarinteraktion** via konfigurerbara knappanslutningar
+
+![Vy inuti HALPI2](./halpi2-interior.jpg)
+*Vy inuti HALPI2 med bärkortet och de olika anslutningarna.*
+
+### Programvarans egenskaper
+
+- **Förkonfigurerade systemavbilder** klara att använda direkt: [HaLOS](https://docs.halos.fi) (standard), OpenPlotter, Raspberry Pi OS och Raspberry Pi OS Lite
+- **Omfattande övervakning** av spänning, ström och temperatur
+- **Diskreta firmwareuppdateringar** via I2C-gränssnittet
+
+## Användningsområden
+
+### Marina tillämpningar
+
+- **Navigationssystem** med kartplotter och GPS-integration
+- **Datalagring** av motorvärden, miljösensorer och fartygets prestanda
+- **Signal K-servrar** för enhetlig hantering av båtens data
+- **Allmän dator ombord** för internetuppkoppling och kommunikation
+- **Felsökning av NMEA 2000-nätverk** för högre systemtillförlitlighet
+
+### Industriella tillämpningar
+
+- **Processövervakning** och styrsystem
+- **Miljömätning** och datainsamling
+- **Stationer för fjärrövervakning**
+- **Automation och styrning av utrustning**
+- **System för förebyggande underhåll**
+
+### Fordonstillämpningar
+
+- **System för flotthantering**
+- **Telematik** och fordonsspårning
+- **Infotainmentsystem i fordon**
+- **Plattformar för diagnostik och övervakning**
+
+## Förpackningens innehåll
+
+HALPI2-förpackningen innehåller:
+
+- **HALPI2-enheten** med förinstallerad Compute Module 5 och NVMe SSD (om den inte beställts utan)
+- **En strömkabel** med E7T-kontakt (kompatibel med Amphenol LTW Ceres Mini), längd 2 m
+- **En E7T-kabelkontakt** för egna installationer
+- **Ett par DC-hålkontakter** (5,5 × 2,1 mm) för vanliga nätaggregat på 12 V/24 V
+- **En Raspberry Pi-antenn** för WiFi och Bluetooth
+- **3 st PG7-kabelgenomföringar** för ytterligare gränssnitt
+- **En snabbstartsguide och garantihandlingar**
+
+![Innehållet i HALPI2:s tillbehörspåse](./goodie-bag-contents.jpg)
+
+Tillbehör som säljs separat:
+
+- **NMEA 2000-stickledning** för installationer med bussmatning
+- **Olika kontaktsatser** för egna installationer
+
+## Så använder du den här dokumentationen
+
+Dokumentationen vänder sig både till slutanvändare som söker praktisk vägledning och till utvecklare som behöver detaljerad teknisk information.
+
+### För slutanvändare
+
+- Börja med guiden **Kom igång** för installation och driftsättning
+- Läs om **vanliga användningsfall** för råd som passar din tillämpning
+- Gå till **Felsökning** när problem uppstår
+
+### För utvecklare
+
+- Läs **Teknisk referens** för detaljerade specifikationer
+- Studera avsnitten om **Programvaruutveckling** för egna tillämpningar
+- Titta på **Konstruktionsfilerna** när du planerar en integration
+- Se **Avancerad konfiguration** för prestandaoptimering
+
+### Konventioner i dokumentationen
+
+- 💡 **Tips**-rutor ger genvägar för vanliga uppgifter
+- ⚠️ **Varning** och **Observera** lyfter fram viktig säkerhetsinformation
+- 🔧 **Tekniska detaljer** går djupare in på hur något är genomfört
+- 📖 **Korsreferenser** binder samman besläktade ämnen genom hela dokumentationen
+
+Oavsett om du sätter upp din första båtdator eller utvecklar en egen industriell lösning tar den här dokumentationen dig genom varje steg.

--- a/docs/sv/software-development/advanced-config.md
+++ b/docs/sv/software-development/advanced-config.md
@@ -1,3 +1,7 @@
+---
+translated_from: 7cd96fcdbd05d13cf6d7a0aece5e788de8ca9c62
+---
+
 # Avancerad konfiguration
 
 - Prestandaoptimering

--- a/docs/sv/software-development/advanced-config.md
+++ b/docs/sv/software-development/advanced-config.md
@@ -1,0 +1,7 @@
+# Avancerad konfiguration
+
+- Prestandaoptimering
+- Uppsättning av realtidssystem
+- Integration av egen hårdvara
+- Säkerhetshärdning
+- Strategier för säkerhetskopiering och återställning

--- a/docs/sv/software-development/daemon.md
+++ b/docs/sv/software-development/daemon.md
@@ -1,0 +1,7 @@
+# HALPI2-daemon
+
+- Installation och konfiguration
+- API-referens
+- Integration med systemtjänster
+- Egna övervakningsskript
+- Hantering av Debian-paket

--- a/docs/sv/software-development/daemon.md
+++ b/docs/sv/software-development/daemon.md
@@ -1,3 +1,7 @@
+---
+translated_from: 4312a0e2c31bc8816de0a9735b84742671efda43
+---
+
 # HALPI2-daemon
 
 - Installation och konfiguration

--- a/docs/sv/software-development/integration.md
+++ b/docs/sv/software-development/integration.md
@@ -1,0 +1,7 @@
+# Systemintegration
+
+- Device tree-overlays
+- Konfiguration av kärnmoduler
+- Tjänstehantering
+- Bygga egna systemavbilder
+- Uppsättning av korskompilering

--- a/docs/sv/software-development/integration.md
+++ b/docs/sv/software-development/integration.md
@@ -1,3 +1,7 @@
+---
+translated_from: 0ef15a1b16d45ab5bbb343c19900513802350f96
+---
+
 # Systemintegration
 
 - Device tree-overlays

--- a/docs/sv/software-development/ubuntu-installation.md
+++ b/docs/sv/software-development/ubuntu-installation.md
@@ -1,0 +1,171 @@
+# Använda andra Debian-baserade distributioner
+
+!!! warning "Obs"
+    Hat Labs kan inte ge support för installation och användning av operativsystem från tredje part. Anvisningarna nedan är en service till användare som vill köra HALPI2 med en egen programvaruuppsättning.
+
+HALPI2 fungerar med vilket operativsystem som helst som stöder Raspberry Pi Compute Module 5. För att få tillgång till hela HALPI2-hårdvarans funktionalitet, inklusive strömhantering och övervakning, måste operativsystemet stödja HALPI2-daemonen (`halpid`), och en del inställningar krävs. På Debian-baserade Linux-distributioner är stegen ganska enkla. Det här avsnittet går igenom installationen av Ubuntu på HALPI2 steg för steg. För andra Debian-baserade distributioner kan mindre justeringar behövas.
+
+Ubuntu har en officiell [Ubuntu-avbild för Raspberry Pi](https://ubuntu.com/download/raspberry-pi) Compute Module 5 som går att använda med HALPI2.
+
+## Förutsättningar
+
+När den valda Ubuntu-avbilden (eller någon annan Debian-baserad avbild) är installerad på din Pi, se till att programvaran är uppdaterad:
+
+```bash
+sudo bash
+apt update
+apt full-upgrade
+apt auto-remove
+exit
+```
+
+Installera sedan följande paket, som behövs för installationen:
+
+```bash
+sudo apt install curl openssh-server dpkg-dev i2c-tools npm net-tools iw git
+```
+
+## Hat Labs paketförråd
+
+De färdigbyggda paketen för HALPI2 kommer från Hat Labs och finns i ett apt-paketförråd. För att lägga till förrådet kör du följande kommandon med root-behörighet (från `sudo bash`):
+
+```bash
+sudo bash
+curl -fsSL https://apt.hatlabs.fi/hat-labs-apt-key.asc | gpg --dearmor > /etc/apt/trusted.gpg.d/hatlabs.gpg
+cat > /etc/apt/sources.list.d/hatlabs.sources << EOF
+Types: deb
+URIs: https://apt.hatlabs.fi/
+Suites: stable
+Components: main
+Signed-By: /etc/apt/trusted.gpg.d/hatlabs.gpg
+EOF
+apt update
+exit
+```
+
+## HALPI2:s gemensamma firmware
+
+Firmwaren för de gemensamma enheterna på HALPI2-kortet konfigureras genom att du redigerar `/boot/firmware/config.txt` och lägger till följande rader i avsnittet `[all]`:
+
+```text
+# --- HALPI2 / Raspberry Pi 5 IO setup ---
+
+# Use antenna path #2 for Wi-Fi/BT
+dtparam=ant2
+
+# Enable SPI0 and relocate CS1 to GPIO6 (BCM6) for the CAN controller.
+dtoverlay=spi0-2cs,cs1_pin=6
+
+# Attach a Microchip MCP2517FD/2518FD CAN-FD controller to SPI0 Chip-Select 1.
+#  - spi0-1        : controller is on SPI0, CS1 (wired to GPIO6 by the overlay above)
+#  - interrupt=26  : MCP251xFD INT pin wired to GPIO26
+#  - oscillator=40000000 : external crystal is 40 MHz
+# Produces a SocketCAN interface (e.g. can0).
+dtoverlay=mcp251xfd,spi0-1,interrupt=26,oscillator=40000000
+
+# Enable PL011 UART4.  Creates /dev/ttyAMA4 for NMEA 0183 communication.
+dtoverlay=uart4-pi5
+```
+
+Därefter måste I2C-gränssnittet aktiveras så att daemonen `halpid`, som körs i användarrymden, kan kommunicera med strömhanteringens hårdvara. Det gör du genom att skapa filen `/etc/modules-load.d/i2c-dev.conf`:
+
+```bash
+sudo echo i2c-dev > /etc/modules-load.d/i2c-dev.conf
+```
+
+## Uppsättning av CAN-bussen (NMEA 2000)
+
+Följande kommando aktiverar CAN-bussen för NMEA 2000-kommunikation på HALPI2:
+
+```bash
+sudo bash
+apt install can-utils
+cat > /etc/systemd/network/80-can.network << EOF
+[Match]
+Name=can*
+
+[CAN]
+BitRate=250000
+RestartSec=100ms
+EOF
+chmod 644 /etc/systemd/network/80-can.network
+echo 'SUBSYSTEM=="net", KERNEL=="can*", ACTION=="add|change", ATTR{tx_queue_len}="1000"' > /etc/udev/rules.d/80-can.rules
+chmod 644 /etc/udev/rules.d/80-can.rules
+systemctl enable systemd-networkd
+reboot
+```
+
+När systemet har startat om kan du kontrollera att CAN-gränssnittet finns med något av kommandona:
+
+```bash
+ip link show can0
+ifconfig can0
+```
+
+## HALPI2-daemon
+
+HALPI2-daemonen övervakar och styr HALPI2:s bärkort och tillhandahåller kommandoradsverktyget `halpi`. Installera paketet `halpid` från Hat Labs paketförråd:
+
+```bash
+sudo apt install halpid
+```
+
+HALPI2-daemonen ska nu vara igång och kommandot `halpi` tillgängligt. Du kontrollerar daemonens status med:
+
+```bash
+halpi status
+```
+
+## Installation av HALPI2:s firmware
+
+Nu när kommandot `halpi` är tillgängligt kan du installera paketet `halpi2-firmware`, som flashar den senaste firmwaren till HALPI2-kortet:
+
+```bash
+apt install halpi2-firmware
+```
+
+Firmwaren kan också flashas manuellt:
+
+```bash
+halpi flash /usr/share/halpi2/firmware/halpi2-rs-firmware_VERSION.bin
+```
+
+## Uppsättning av Signal K-server
+
+Signal K-servern är ett populärt val för hantering av marina data och kan läsa både NMEA 2000- och NMEA 0183-källor. Den installeras med npm. Följande kommandon installerar servern och kör den inledande konfigurationen:
+
+```bash
+npm i -g signalk-server
+signalk-server-setup
+```
+
+Därefter når du Signal K-servern från en webbläsare på den port du har ställt in.
+
+### NMEA 2000-anslutning i Signal K
+
+För att skapa en NMEA 2000-anslutning till HALPI:s CAN-gränssnitt behöver du ett administratörskonto i Signal K. Gå till `Server > Data Connections` i menyn, klicka på `+Add` och skapa en anslutning med följande egenskaper:
+
+```text
+          Data Type: NMEA2000
+            Enabled: Yes
+                 ID: "HALPI2N2K"
+   NMEA 2000 Source: Canbus (canboatjs)
+          Interface: can0
+```
+
+Starta om och kontrollera på instrumentpanelen om data kommer in.
+
+### NMEA 0183-anslutning i Signal K
+
+Även för en NMEA 0183-anslutning behöver du ett administratörskonto i Signal K. Gå till `Server > Data Connections` i menyn, klicka på `+Add` och skapa en anslutning med minst följande egenskaper:
+
+```text
+          Data Type: NMEA0183
+            Enabled: Yes
+                 ID: "HALPI2N0183"
+   NMEA 0183 Source: Serial
+        Serial Port: /dev/ttyAMA4
+          Baud Rate: 4800 | 34800
+```
+
+Starta om och kontrollera på instrumentpanelen om data kommer in.

--- a/docs/sv/software-development/ubuntu-installation.md
+++ b/docs/sv/software-development/ubuntu-installation.md
@@ -1,3 +1,7 @@
+---
+translated_from: 8c2d1560ad56e730c3fe6476cd5cf075b632b539
+---
+
 # Använda andra Debian-baserade distributioner
 
 !!! warning "Obs"

--- a/docs/sv/technical-reference/controller.md
+++ b/docs/sv/technical-reference/controller.md
@@ -1,3 +1,7 @@
+---
+translated_from: c10fce7935a4a3da34e1ce003c5a924eed68b8be
+---
+
 # Bärkortets styrkrets
 
 - RP2040-firmwarens funktioner

--- a/docs/sv/technical-reference/controller.md
+++ b/docs/sv/technical-reference/controller.md
@@ -1,0 +1,7 @@
+# Bärkortets styrkrets
+
+- RP2040-firmwarens funktioner
+- I2C-kommunikationsprotokoll
+- Statusövervakning och rapportering
+- Rutiner för firmwareuppdatering
+- Utveckling av egen firmware

--- a/docs/sv/technical-reference/hardware.md
+++ b/docs/sv/technical-reference/hardware.md
@@ -1,0 +1,247 @@
+# Hårdvarureferens
+
+Den här sidan innehåller HALPI2:s elektriska, mekaniska och miljörelaterade specifikationer. För arbetsgångar (installation, underhåll, byte), se [Hårdvaruguiden](../user-guide/hardware.md). För detaljer om gränssnittens protokoll, se [Gränssnitt och anslutningar](./interfaces.md).
+
+## Specifikationer i korthet
+
+| Parameter | Värde |
+|:----------|:------|
+| Beräkningsmodul | Raspberry Pi CM5 (kompatibel med CM4) |
+| Bärkortets styrkrets | RP2040 (Arm Cortex-M0+, två kärnor, 133 MHz) |
+| Inspänning | 9–36 V DC (absolut max 38,6 V, transientskydd upp till 100 V) |
+| Effektförbrukning | 250 mA i vila till 590 mA under belastning (12 V ingång, HaLOS utan skärm) |
+| Inställningar för strömbegränsning | 0,9 A eller 2,5 A (valbart) |
+| Backup med superkondensatorer | 4× 25 F / 2,7 V i serie (effektivt 6,25 F vid högst 10,8 V) |
+| Driftstemperatur | −20 °C … +60 °C |
+| Kapslingens mått | 200 × 130 × 60 mm (utan kontakter) |
+| Kapslingens vikt | TODO |
+| Kapslingens material | Pulverlackerad pressgjuten aluminium |
+| Kapslingsklass | IP65 |
+| Licens | CERN-OHL-S v2 (hårdvara) |
+
+## Elektriska specifikationer
+
+### Strömförsörjning
+
+Strömförsörjningen tar emot ett brett likspänningsområde och ger reglerade 5 V- och 3,3 V-skenor till CM5 och kringenheterna. Ingångsskyddet omfattar skydd mot omvänd polaritet (LM74800), överspänningsfrånkoppling vid 38,6 V, TVS-begränsning samt EMI-filtrering för både common mode och differentiella störningar.
+
+| Parameter | Värde |
+|:----------|:------|
+| Rekommenderad inspänning | 9–36 V DC |
+| Absolut högsta inspänning | 38,6 V (kontinuerligt), 100 V (transient, TVS-begränsad) |
+| Högsta inström | 0,9 A eller 2,5 A (valbar strömbegränsare) |
+| Ingångssäkring | 7 A (endast felskydd) |
+| 10 V-mellanskena | nominellt 10,25 V (nedomvandlare SiC463ED) |
+| 5 V-skena | 5,1 V / 4 A (TPS566238, matar CM5 och USB-portarna) |
+| 3,3 V-skena | 3,33 V / 3 A (TPS566238, styrkretsstyrd från v0.6.0) |
+| Underspänningströskel 3,3 V | 4,5 V på superkondensatorerna |
+| Tidig 3,3 V-LDO | SE8633K2 (för start av styrkrets och balanseringskrets) |
+
+### Backup med superkondensatorer
+
+Superkondensatorbanken ger backupström för en kontrollerad avstängning vid spänningsbortfall.
+
+| Parameter | Värde |
+|:----------|:------|
+| Uppbyggnad | 4 celler 25 F / 2,7 V i serie |
+| Effektiv kapacitans | 6,25 F vid högst 10,8 V |
+| Balansering | Aktiv balansering |
+| Laddspänningsområde | 0–10,8 V (övervakas av styrkretsens AD-omvandlare) |
+| Påslagströskel | 8,0 V (ställbar i firmwaren) |
+| Avstängningströskel | 5,5 V (ställbar i firmwaren) |
+
+### Strömförbrukning
+
+Uppmätt vid 12 V inspänning med en Raspberry Pi CM5 som kör HaLOS-avbilden utan skärm.
+
+| Tillstånd | Strömuttag |
+|:----------|:-----------|
+| Systemet i vila | ca 250 mA |
+| Typisk belastning | ca 400 mA |
+| Toppbelastning | ca 590 mA |
+
+!!! note
+    Mätvärdena omfattar inte förbrukningen hos externa USB-enheter. Varje USB 3.0-port kan leverera upp till 0,93 A, så systemets totala strömuttag beror i hög grad på anslutna kringenheter.
+
+## Kontakternas stiftlägen
+
+### Kontakt för strömförsörjning
+
+Typ Phoenix MC, delning 3,81 mm, 2-polig. På frontpanelen ansluts E7T-hålkontakten till den här anslutningen.
+
+| Stift | Funktion |
+|:------|:---------|
+| 1 | GND |
+| 2 | VIN (9–36 V DC) |
+
+### CAN FD-kontakt
+
+Typ Phoenix MC, delning 3,81 mm, 4-polig. Galvaniskt isolerad.
+
+| Stift | Funktion |
+|:------|:---------|
+| 1 | GND_CAN (isolerad jord) |
+| 2 | — |
+| 3 | CAN_H |
+| 4 | CAN_L |
+
+Termineringsbygeln (märkt ”120R”) kopplar in ett termineringsmotstånd på 120 Ω mellan CAN_H och CAN_L.
+
+### RS-485-kontakt
+
+Typ Phoenix MC, delning 3,81 mm, 5-polig. Galvaniskt isolerad.
+
+| Stift | Funktion |
+|:------|:---------|
+| 1 | GND_RS485 (isolerad jord) |
+| 2 | RX_A_C |
+| 3 | RX_B_C |
+| 4 | TX_A_C |
+| 5 | TX_B_C |
+
+### Knappanslutning
+
+2×3-polig stiftlist, delning 2,54 mm. Varje knappar utgörs av GND och en signal.
+
+| Stiftpar | Funktion |
+|:---------|:---------|
+| Power | CM5:ns strömknapp (dubbelklick = avstängning, långt tryck = framtvingad avstängning) |
+| Reset | Hårdvarureset av RP2040 (RUN-stiftet) |
+| User | Konfigurerbar av användaren (väntar på implementation i firmwaren) |
+
+### HDMI-kontakter (HDMI0, HDMI1)
+
+20-poliga vågräta FFC-kontakter, delning 0,5 mm (FPC0.5-SMT-20P). Varje kanal har ESD-skydd (RCLAMP0524P) och strömbegränsad 5 V-matning (AP2553W6-7).
+
+### MIPI CSI/DSI-kontakter (MIPI0, MIPI1)
+
+22-poliga vågräta FFC-kontakter, delning 0,5 mm. Varje kanal har ESD-skydd (RCLAMP0524P). Kompatibla med Raspberry Pi:s kamera- och skärmmoduler.
+
+### M.2 NVMe-plats (PCIe M.2 M-key)
+
+M.2 Socket M för NVMe SSD-enheter, stöder formaten 2230 till 2280. Ansluten via PCIe Gen 2 x1. Har en egen SUSCLK-oscillator för kompatibilitet med NVMe-enheters viloläge (tillagd i v0.6.1).
+
+### Fläktanslutningar (CM5 Fan)
+
+4-poliga PWM-fläktanslutningar (HC-1.0-4PLT) finns på bärkortets över- och undersida. De är parallellkopplade — använd bara en åt gången.
+
+| Stift | Funktion |
+|:------|:---------|
+| 1 | +5V |
+| 2 | FAN_PWM |
+| 3 | FAN_TACHO |
+| 4 | GND |
+
+### USB 3.0-portar
+
+| Kontakt | Anslutning | Strömbegränsning |
+|:--------|:-----------|:-----------------|
+| USB3-0 | Direkt till CM5:ns USB 3.0 | 0,93 A (AP22652W6-7) |
+| USB3-1-0 | Port 1 på USB3-hubben (UPD720210) | 0,93 A |
+| USB3-1-1 | Port 2 på USB3-hubben | 0,93 A |
+| USB3-1-2 | Port 3 på USB3-hubben | 0,93 A |
+
+Alla portar har ESD-skydd (RCLAMP0524P) och filtrering med ferritpärlor.
+
+### Styrkretsens USB-port (MCU USB)
+
+Micro-USB-uttag, endast USB 2.0 i enhetsläge. Används för firmwareuppdatering av RP2040 (UF2-flashning). ESD-skyddad (RCLAMP0524P).
+
+### USB-startport (USB Boot)
+
+USB Type-C-uttag, USB 2.0 i enhetsläge. Ansluten till CM5:ns USB 2.0 OTG-port för start från USB-masslagring. ESD-skyddad (RCLAMP0524P).
+
+## 40-polig GPIO-stiftlist (Raspberry Pi GPIO Header)
+
+GPIO-stiftlisten följer Raspberry Pi:s vanliga 40-poliga utförande. Följande stift används av HALPI2:s inbyggda kringenheter:
+
+| GPIO | Stift | Funktion | Gränssnitt | Delas? |
+|:-----|:------|:---------|:-----------|:-------|
+| 2 | 3 | I2C1 SDA | Systemets I2C | Ja (adress 0x6d reserverad) |
+| 3 | 5 | I2C1 SCL | Systemets I2C | Ja (adress 0x6d reserverad) |
+| 6 | 31 | SPI0 CS | CAN FD-styrkrets | Eget kretsval — kan samexistera med standardstiften för CS |
+| 9 | 21 | SPI0 MISO | CAN FD-styrkrets | Delad SPI0-buss |
+| 10 | 19 | SPI0 MOSI | CAN FD-styrkrets | Delad SPI0-buss |
+| 11 | 23 | SPI0 SCLK | CAN FD-styrkrets | Delad SPI0-buss |
+| 12 | 32 | UART4 TX | RS-485 | Ledigt om RS-485 är avstängt |
+| 13 | 33 | UART4 RX | RS-485 | Ledigt om RS-485 är avstängt |
+| 24 | 18 | RS-485 EN | RS-485 (manuellt läge) | Ledigt i automatiskt läge |
+| 26 | 37 | CAN INT | CAN FD-styrkrets | Nej |
+
+Alla övriga GPIO-stift är tillgängliga för HAT-kort och egna tillämpningar. [Hårdvaruguiden](../user-guide/hardware.md#using-hats) beskriver HAT-kompatibiliteten och hur de inbyggda gränssnitten stängs av.
+
+## I2C-enheter
+
+På systemets I2C-buss (I2C1, GPIO 2/3) sitter följande enheter:
+
+| Adress | Enhet | Funktion |
+|:-------|:------|:---------|
+| 0x4b | TMP112A | Temperatursensor på kortet |
+| 0x6d | RP2040 | Bärkortets styrkrets (slavläge) |
+
+Styrkretsens I2C-buss (I2C0, intern på bärkortet) används för HDMI:s DDC-kommunikation och för MIPI-skärmar, med pull-up-motstånd på 2,2 kΩ.
+
+## Isolationens uppbyggnad
+
+CAN FD- och RS-485-gränssnitten är galvaniskt isolerade från resten av systemet. Varje gränssnitt har egen isolerad matning (DC-DC-omvandlare B0505S-1WR3) och egen signalisolation.
+
+| Gränssnitt | Signalisolation | Matningsisolation | Isolerad jord |
+|:-----------|:----------------|:------------------|:--------------|
+| CAN FD | ISO7721DR | B0505S-1WR3 | GND_CAN |
+| RS-485 | TI41M31 | B0505S-1WR3 | GND_RS485 |
+
+Fel på bussen, jordslingor och störningar i CAN- eller RS-485-nätverken kan därför varken skada huvudsystemet eller störa det.
+
+## Mekaniska specifikationer
+
+### Kapsling
+
+| Parameter | Värde |
+|:----------|:------|
+| Material | Pulverlackerad pressgjuten aluminium |
+| Mått | 200 × 130 × 60 mm (utan kontakter) |
+| Vikt | TODO |
+| IP-klass | IP65 |
+| Fri höjd ovanför bärkortet | 45 mm (rymmer upp till två staplade HAT-kort) |
+| Lockets skruvar | 4× M4×10 försänkt skalle, PH2 |
+| Packning | Lockpackning för väderbeständighet |
+| Tryckutjämning | Tryckutjämningsplugg (får inte tas bort) |
+
+### Platser på frontpanelen
+
+Frontpanelen har förborrade platser för:
+
+- 1× E7T-strömkontakt
+- 1× NMEA 2000 Micro-C-kontakt
+- 1× RJ45-ethernet
+- 2× HDMI Type-A
+- 2× USB 3.0 Type-A
+- 1× RP-SMA-antennkontakt (WiFi/Bluetooth)
+- 2× SMA-antennplatser (levereras med blindpluggar)
+- 1× tryckutjämningsplugg
+- 3× platser för PG7-kabelgenomföring (levereras med blindpluggar)
+
+### Montering
+
+- Montering av bärkortet: 4× M4×6-skruvar i kapslingens botten
+- Montering av HAT-kort: 4× M2.5-gänginsatser (från v0.5.0; v0.4.0 kräver att muttrarna sätts för hand)
+- Montering av CM5: 4× M2.5-lödmuttrar
+
+## Värmehantering
+
+CM5 sitter på bärkortets undersida. Värmen från CM5:ns SoC och RP1-kretsuppsättning leds via värmeledande dynor till kapslingens aluminiumbotten, som fungerar som kylfläns.
+
+| Komponent | Dynans tjocklek |
+|:----------|:----------------|
+| SoC (BCM2712) | 1 mm |
+| RP1 | 2 mm |
+| Strömförsörjningens komponenter | 2 mm |
+
+Standardkapslingen kyls passivt, utan fläkt. En 4-polig PWM-fläktanslutning finns för egna kapslingar eller tillämpningar med hög omgivningstemperatur.
+
+!!! quote "Relaterad information"
+    - **Kopplingsscheman och konstruktionsfiler:** se [Konstruktionsfiler och kopplingsscheman](../appendices/design-files.md)
+    - **Strömhanteringens beteende:** se [Strömförsörjningen i detalj](./power-supply.md)
+    - **Gränssnittsprotokoll:** se [Gränssnitt och anslutningar](./interfaces.md)
+    - **Styrkrets och I2C-protokoll:** se [Bärkortets styrkrets](./controller.md)
+    - **Fysisk installation:** se [Hårdvaruguiden](../user-guide/hardware.md)

--- a/docs/sv/technical-reference/hardware.md
+++ b/docs/sv/technical-reference/hardware.md
@@ -1,3 +1,7 @@
+---
+translated_from: c237d8b6a74b99528445a8bb38aa5473b824b52e
+---
+
 # Hårdvarureferens
 
 Den här sidan innehåller HALPI2:s elektriska, mekaniska och miljörelaterade specifikationer. För arbetsgångar (installation, underhåll, byte), se [Hårdvaruguiden](../user-guide/hardware.md). För detaljer om gränssnittens protokoll, se [Gränssnitt och anslutningar](./interfaces.md).
@@ -168,7 +172,7 @@ GPIO-stiftlisten följer Raspberry Pi:s vanliga 40-poliga utförande. Följande 
 | 24 | 18 | RS-485 EN | RS-485 (manuellt läge) | Ledigt i automatiskt läge |
 | 26 | 37 | CAN INT | CAN FD-styrkrets | Nej |
 
-Alla övriga GPIO-stift är tillgängliga för HAT-kort och egna tillämpningar. [Hårdvaruguiden](../user-guide/hardware.md#using-hats) beskriver HAT-kompatibiliteten och hur de inbyggda gränssnitten stängs av.
+Alla övriga GPIO-stift är tillgängliga för HAT-kort och egna tillämpningar. [Hårdvaruguiden](../user-guide/hardware.md#att-anvanda-hat-kort) beskriver HAT-kompatibiliteten och hur de inbyggda gränssnitten stängs av.
 
 ## I2C-enheter
 

--- a/docs/sv/technical-reference/interfaces.md
+++ b/docs/sv/technical-reference/interfaces.md
@@ -1,0 +1,87 @@
+# Gränssnitt och anslutningar
+
+Den här sidan beskriver hur CM5:ns gränssnitt är utförda på HALPI2:s bärkort.
+För daglig användning av de inbyggda CAN FD- och RS-485-portarna, se
+användarhandboken [Gränssnitt och anslutningar](../user-guide/interfaces.md).
+
+## Serieportar (UART)
+
+Compute Module 5 når den 40-poliga stiftlisten via sin RP1-I/O-styrkrets, som
+tillhandahåller fem UART:ar (`uart0`–`uart4`). Varje UART är fast kopplad till
+ett bestämt GPIO-par — till skillnad från tidigare Pi-modeller går stiften inte
+att flytta. Inloggningskonsolen är en separat, dedikerad felsöknings-UART
+(`/dev/ttyAMA10`) och hör inte till dessa.
+
+| UART | TX / RX | Stift på listen | Linux-enhet | Tillgänglighet på HALPI2 |
+|:-----|:--------|:----------------|:------------|:-------------------------|
+| `uart0` | GPIO14 / 15 | 8 / 10 | `/dev/ttyAMA0` | Ledig. Vanlig seriell HAT-port; används av GNSS-HAT-kort. |
+| `uart1` | GPIO0 / 1 | 27 / 28 | `/dev/ttyAMA1` | Ledig. Detta är stiften för HAT-identifieringens EEPROM (ID_SD / ID_SC). |
+| `uart2` | GPIO4 / 5 | 7 / 29 | `/dev/ttyAMA2` | Ledig. |
+| `uart3` | GPIO8 / 9 | 24 / 21 | `/dev/ttyAMA3` | Upptagen av CAN FD-styrkretsen (SPI0). |
+| `uart4` | GPIO12 / 13 | 32 / 33 | `/dev/ttyAMA4` | Upptagen av RS-485. |
+
+### Aktivera en UART
+
+Lägg till motsvarande `-pi5`-overlay i `/boot/firmware/config.txt` och starta om:
+
+```
+dtoverlay=uart2-pi5
+```
+
+`uart0` aktiveras i stället med `dtparam=uart0=on`. (På en CM5 styr firmwaren om
+de enkla `uartN`-overlayerna till sina `uartN-pi5`-motsvarigheter, så båda namnen
+fungerar; `-pi5`-formen används här för tydlighetens skull.)
+
+Hårdvarustyrd flödeskontroll aktiveras uttryckligen med parametern `ctsrts`, och
+overlayerna kan styra en RS-485-transceivers aktiveringssignal direkt med
+parametern `rs485`:
+
+```
+dtoverlay=uart2-pi5,ctsrts
+```
+
+CTS/RTS upptar nästa GPIO-par, som på HALPI2 ofta redan är i bruk:
+
+| UART | CTS / RTS | Krockar med |
+|:-----|:----------|:------------|
+| `uart1` | GPIO2 / 3 | Systemets I2C-buss (I2C1) |
+| `uart2` | GPIO6 / 7 | CAN FD:s kretsval |
+| `uart3` | GPIO10 / 11 | CAN FD:s SPI-buss |
+| `uart4` | GPIO14 / 15 | `uart0` |
+
+`uart1` är därför i praktiken bara användbar som ren TX/RX-port.
+
+### Frigöra en upptagen UART
+
+`uart3` och `uart4` överlappar kortets CAN FD- och RS-485-gränssnitt:
+
+- **`uart3`** delar SPI0-bussen med CAN FD-styrkretsen — GPIO9 är styrkretsens
+  datautgång (SDO). Att använda `uart3` kräver att CAN-gränssnittet stängs av
+  och att hårdvaran modifieras, och stöds inte på standardkortet.
+- **`uart4`** är RS-485-porten. Om kortets bygel för RX-aktivering tas bort
+  kopplas RS-485-mottagaren från GPIO13 och `uart4` frigörs för allmän
+  användning. RS-485 är då inte tillgängligt.
+
+Stegen på hårdvarusidan beskrivs under
+[Stänga av inbyggda gränssnitt](../user-guide/hardware.md#using-hats).
+
+### Kontroll
+
+Kontrollera efter omstarten att enhetsnoden finns och att stiften har den
+förväntade funktionen:
+
+```
+ls /dev/ttyAMA*
+pinctrl funcs | grep -iE 'txd|rxd'
+pinctrl 4 5
+```
+
+De valda stiften ska rapportera sin UART-funktion (`a2` för `uart1`–`uart4`,
+`a4` för `uart0`).
+
+## Övriga ämnen
+
+- Detaljer kring NMEA 2000-implementationen
+- USB 3.0-specifikationer och strömhantering
+- Ethernet och nätverk
+- Krav på M.2 NVMe-lagring

--- a/docs/sv/technical-reference/interfaces.md
+++ b/docs/sv/technical-reference/interfaces.md
@@ -1,3 +1,7 @@
+---
+translated_from: 9497de10027831b20a1e2278a32df0c12d9a4a39
+---
+
 # Gränssnitt och anslutningar
 
 Den här sidan beskriver hur CM5:ns gränssnitt är utförda på HALPI2:s bärkort.
@@ -63,7 +67,7 @@ CTS/RTS upptar nästa GPIO-par, som på HALPI2 ofta redan är i bruk:
   användning. RS-485 är då inte tillgängligt.
 
 Stegen på hårdvarusidan beskrivs under
-[Stänga av inbyggda gränssnitt](../user-guide/hardware.md#using-hats).
+[Stänga av inbyggda gränssnitt](../user-guide/hardware.md#att-anvanda-hat-kort).
 
 ### Kontroll
 

--- a/docs/sv/technical-reference/power-supply.md
+++ b/docs/sv/technical-reference/power-supply.md
@@ -1,3 +1,7 @@
+---
+translated_from: 5229ab5363e54a19e4330c30051e4787ece5806e
+---
+
 # Strömförsörjningen i detalj
 
 - Inspänningsområden och skydd

--- a/docs/sv/technical-reference/power-supply.md
+++ b/docs/sv/technical-reference/power-supply.md
@@ -1,0 +1,7 @@
+# Strömförsörjningen i detalj
+
+- Inspänningsområden och skydd
+- Backup med superkondensatorer
+- Strömbegränsning och lasthantering
+- Sekvens för på- och avslagning
+- Skydd mot underspänning och spänningstoppar

--- a/docs/sv/user-guide/hardware.md
+++ b/docs/sv/user-guide/hardware.md
@@ -1,0 +1,354 @@
+---
+translated_from: 9741366021074655d667fcf3a93a634f86f3519a
+---
+
+# Hårdvaruguide
+
+## Åtkomst till kapslingen
+
+HALPI2 har en pulverlackerad kapsling i pressgjuten aluminium med förborrade hål för panelkontakter. När interna ändringar eller underhåll behövs kommer du åt insidan enligt anvisningarna nedan.
+
+### Öppna kapslingen
+
+För att komma åt de interna komponenterna börjar du med att se till att enheten är helt avstängd och att strömkablarna är bortkopplade. Locket hålls på plats av fyra försänkta M4x10-skruvar med PH2-huvud. Ta bort skruvarna med en PH2-skruvmejsel och lyft av locket.
+
+### Återmontering
+
+Innan du sätter ihop kapslingen igen bör du kontrollera att alla interna anslutningar sitter ordentligt och är rätt monterade. Dra kablarna omsorgsfullt så att de inte kläms eller får skarpa böjar.
+
+Det är lätt att råka koppla in de böjliga flatkablarna (FFC) bakvänt. Kontrollera riktningen mot pilarna märkta ”Contacts” i tryckskiktet.
+
+Var särskilt noga med lockets packning: kontrollera att den inte är skadad, smutsig eller förskjuten, eftersom det skulle försämra kapslingens täthet.
+
+Sätt tillbaka lockets fyra M4x10-skruvar med PH2-skruvmejseln. Dra inte åt för hårt.
+
+
+## Panelkontakter
+
+### Standardutförande
+
+HALPI2 levereras med ett standardutförande av kontakter som passar de flesta tillämpningar. Standardplaceringen omfattar:
+
+- **E7T-strömkontakt**
+- **NMEA 2000 Micro-C-kontakt**
+- **Gigabit-ethernet RJ45**
+- **HDMI-utgång**
+- **2× USB 3.0 typ A**
+- **3× platser för PG7-kabelgenomföring** (med blindpluggar)
+- **2× platser för RP-SMA-antenn** (med blindpluggar)
+- **Andningsplugg** för tryckutjämning
+
+![Frontpanelens kontakter och blindpluggar](./front-panel-connectors-all.jpg)
+*Frontpanelens kontakter och blindpluggar. Kontakterna märkta med grönt ingår i standardutförandet. De gula platserna är blindpluggar som vid behov kan ersättas med kontakter. Den röda platsen är andningspluggen, som inte får tas bort.*
+
+### Egna kontaktalternativ
+
+Om du behöver andra kontakttyper kan du ändra panelens utförande:
+
+#### Ta bort kontakter
+
+!!! warning "Viktigt"
+    Ändra kontakterna endast när enheten är avstängd och bortkopplad från alla källor.
+
+    Plastgängor skadas lätt om de dras åt för hårt. Använd vanliga hylsnycklar men dra bara åt för hand.
+
+1. **Använd rätt hylsstorlek:**
+    - Stora kontakter: 26 mm hylsa
+    - M6-nylonbultar: 10 mm hylsa
+    - RP-SMA-kontakter: 8 mm hylsa
+    - PG7-platser: stor spårskruvmejsel, 17 mm hylsa
+
+2. **Ta bort försiktigt** — plastgängor skadas lätt om de dras åt för hårt
+
+3. **Spara de borttagna delarna** för eventuellt framtida bruk
+
+#### Montera nya kontakter
+
+1. **Använd endast marina** eller på annat sätt miljöklassade kontakter
+2. **Se till att tätningen blir god** — en bred fläns krävs på insidan
+3. **Dra bara åt för hand** — dra inte åt plastgängorna för hårt
+4. **Provmontera** före den slutliga installationen
+
+## Intern layout
+
+- HALPI2:s bärkort är datorns moderkort. Det bär Compute Module 5 (CM5) på undersidan och sköter strömhantering, indikeringar och anslutningar för alla gränssnitt.
+
+### Bärkortets funktionsområden
+
+Bärkortets viktigaste funktionsområden visas i bilden nedan.
+
+![Bärkortets layout, ovansidan](./carrier-board-top-layout.jpg)
+*Bärkortets layout på ovansidan, med de viktigaste funktionsområdena.*
+
+### Bärkortets kontakter
+
+Funktionerna nås via ett antal kontakter på kortet, som visas i bilden nedan.
+
+![Bärkortets kontakter, ovansidan](./carrier-board-top-conx.jpg)
+*Bärkortets kontakter, ovansidan.*
+
+En förteckning över kontakterna på ovansidan följer nedan.
+
+| Märkning | Beskrivning |
+|:---------|:------------|
+| **a1** | Strömkontakt (typ Phoenix MC, delning 3,81 mm) |
+| **a2** | Omkopplare för strömbegränsning (0,9 A eller 2,5 A) |
+| **a3** | Bygel för strömstyrning. Kortslut stiften ”3.3V off” för att tvinga av 3,3 V-skenan. Kortslut stiften ”5V on” för att tvinga på 5 V-skenan. **Obs:** På kort av version 0.4.0 är kontakterna **a3** och **c2** ordnade på ett annat sätt. |
+| **b1** | Ethernetport (RJ45) |
+| **c1** | Styrkretsens USB-port. Används för att flasha RP2040-mikrokontrollerns firmware. |
+| **c2** | Stiftlist för MCU USB BOOT. Kortslut stiften för att sätta RP2040 i USB-startläge. |
+| **c3** | Stiftlist för felsökning av styrkretsen |
+| **c4** | Obestyckad GPIO-stiftlist för styrkretsen |
+| **c5** | Stiftlister för knappar. Används för att ansluta knapparna Power, Reset och User. |
+| **c6** | Strömknapp. Används för att slå på och stänga av Compute Module 5. |
+| **d1** | Raspberry Pi:s 40-poliga GPIO-stiftlist |
+| **e1** | MIPI0-kontakt för kamera eller skärm |
+| **e2** | MIPI1-kontakt för kamera eller skärm |
+| **f1** | HDMI0-kontakt |
+| **f2** | HDMI1-kontakt |
+| **g1** | M.2-kontakt för NVMe SSD |
+| **h1** | CAN FD-gränssnitt (typ Phoenix MC, delning 3,81 mm) |
+| **h2** | Bygel för CAN-terminering. Kortslut stiften för att koppla in termineringsmotståndet på CAN FD-bussen. |
+| **i1** | RS-485-gränssnitt (typ Phoenix MC, delning 3,81 mm) |
+| **i2** | Bygel för automatisk/manuell aktivering av RS-485. |
+| **i4** | Bygel för XRS-485 RX Enable. Kortslut stiften för att aktivera mottagning av RS-485-trafik. |
+| **j1** | Kontakt för Compute Module USB Boot. Används för att flasha Compute Module 5:s firmware. |
+| **j2** | Omkopplare för Compute Modules startläge. Sätt den i läget ”Normal” för normal drift och i läget ”Abnormal” för USB-startläge. En varningslysdiod tänds när omkopplaren står i läget ”Abnormal”. |
+| **m1** | USB3-kontakt 0. Ansluten direkt till CM5. |
+| **m2** | USB3-kontakt 1-0. Ansluten till USB3-hubben på kortet. |
+| **m3** | USB3-kontakt 1-1. Ansluten till USB3-hubben på kortet. |
+| **m4** | USB3-kontakt 1-2. Ansluten till USB3-hubben på kortet. |
+| **n1** | CR2032-batterihållare för realtidsklockan (RTC) |
+| **q1** | Kontakt för CM5-fläkt. Fläkten kan användas för att förbättra luftcirkulationen inuti kapslingen. Den behövs inte när standardkapslingen används. |
+
+![Bärkortets kontakter, undersidan](./carrier-board-bottom-conx.jpg)
+*Bärkortets kontakter, undersidan.*
+
+En förteckning över kontakterna på undersidan följer nedan.
+
+| Märkning | Beskrivning |
+|:---------|:------------|
+| **p1** | Kontakt för Compute Module 5. |
+| **q1** | Kontakt för CM5-fläkt, alternativ placering. Den här stiftlisten kan användas för att ansluta en processorfläkt ovanpå CM5-modulen i en egen kapsling. **Obs:** Kontakterna **q1** och **q2** är parallellkopplade och får inte användas samtidigt. |
+
+Slutligen sitter antennkontakten för WiFi och Bluetooth på själva Compute Module 5. Den visas i bilden nedan.
+
+![Antennkontakt för WiFi](./cm5-top-conx.jpg)
+*U.FL-antennkontakten på Compute Module 5.*
+
+| Märkning | Beskrivning |
+|:---------|:------------|
+| **r1** | U.FL-kontakt för WiFi- och Bluetooth-antennen. |
+
+### Blinkenlights
+
+Bärkortet har flera statuslysdioder för systemövervakning.
+
+![Bärkortets statuslysdioder](./carrier-board-top-leds.jpg)
+*Bärkortets statuslysdioder och deras färger.*
+
+Statuslysdioderna ger information om systemets ström- och aktivitetstillstånd. En förteckning över dem följer nedan.
+
+| Märkning | Färg | Beskrivning |
+|----------|:-----|:------------|
+| **1** | RGB | Fem RGB-lysdioder. De används för att visa systemets tillstånd och aktivitet på frontpanelen. |
+| **2** | Röd | Strömlysdioder för 3,3 V- och 5 V-skenorna. De visar strömtillståndet för respektive spänningsskena. |
+| **3** | Gul | Indikering av ethernethastighet. Lyser när ethernetporten har förhandlat fram en förbindelse på 100/1000 Mbit/s. |
+| **4** | Grön | Indikering av ethernetaktivitet. Blinkar när det finns nätverkstrafik på ethernetporten. |
+| **5** | Blå | Indikering av SSD-aktivitet. Blinkar när det finns läs- eller skrivaktivitet på M.2 NVMe SSD-enheten. |
+| **6** | Röd | Indikering av Pi:ns strömtillstånd. Lyser när systemet har spänning men är avstängt. |
+| **7** | Grön | Indikering av Pi:ns aktivitet. Blinkar när det finns aktivitet på Raspberry Pi:n. |
+| **8** | Bärnstensgul | Varning för onormalt startläge. Lyser när omkopplaren för USB-startläge står i läget ”Abnormal”. Det betyder att enheten är inställd för flashning via USB Boot-kontakten och inte startar normalt. |
+| **9** | Grön | CAN TX/RX-lysdioder. De blinkar när data tas emot (RX) eller sänds (TX) på CAN-gränssnittet. |
+| **10** | Grön | RS-485 TX/RX-lysdioder. De blinkar när data tas emot (RX) eller sänds (TX) på RS-485-gränssnittet. |
+
+RGB-lysdiodernas mönster beskrivs i [Systemdrift](./operation.md#status-ledar).
+
+## Konfiguration av strömbegränsningen
+
+Bärkortet har en omkopplare för strömbegränsning som ställer in den maximala ström som matas ut till kringenheter. Omkopplaren hittar du som **a2** i bilden i avsnittet [Bärkortets kontakter](#barkortets-kontakter).
+
+!!! info "Inställningar för strömbegränsningen"
+    **Inställningen 0,9 A (standard):**
+
+    - Obligatorisk vid matning från NMEA 2000-bussen
+    - Lämplig för grundläggande drift
+
+    **Inställningen 2,5 A:**
+
+    - För strömtörstiga kringenheter
+    - Snabbare laddning av superkondensatorerna
+    - Endast med egen strömanslutning
+
+För att ändra strömbegränsningen stänger du först av HALPI2 helt och tar bort kapslingens lock enligt anvisningen i avsnittet Åtkomst till kapslingen. Leta upp omkopplaren för strömbegränsning på bärkortet och ställ den i önskat läge (antingen 0,9 A eller 2,5 A). När inställningen är ändrad monterar du ihop kapslingen igen och kontrollerar att alla anslutningar sitter kvar ordentligt.
+
+## Att använda HAT-kort
+
+### HAT-kompatibilitet
+
+HALPI2 stöder vanliga Raspberry Pi HAT-kort via sin 40-poliga GPIO-stiftlist och är fullt elektriskt och mekaniskt kompatibel med HAT-specifikationen. Bärkortet har samma GPIO-stiftläge som en vanlig Raspberry Pi, vilket gör att de flesta HAT-kort avsedda för Raspberry Pi 4 och 5 fungerar utan ändringar. Kompatibiliteten gäller både officiella Raspberry Pi HAT-kort och tredjepartskort som följer HAT-standarden.
+
+### Fysiska begränsningar
+
+HALPI2:s kapsling ger 45 mm fri höjd ovanför bärkortet, vilket räcker för upp till två staplade HAT-kort. Ytan till vänster om det markerade HAT-området upptas av superkondensatorerna, vilket begränsar utrymmet för kort som sträcker sig utanför standardmåtten 65 mm × 56 mm. Var särskilt uppmärksam på HAT-kort med kontakter i kanten. Kontakter som pekar ”söderut” eller ”österut” går bra, men de som pekar ”västerut” kan komma i vägen för superkondensatorerna.
+
+### Konflikter mellan GPIO-stift
+
+Flera GPIO-stift används av HALPI2:s inbyggda gränssnitt och måste beaktas när du väljer HAT-kort. Tabellen nedan visar de reserverade stiften och deras funktioner:
+
+| GPIO-nummer | Funktion | Gränssnitt | Anmärkningar |
+|-------------|----------|------------|--------------|
+| GPIO 2 | I2C SDA | Systemets I2C | Kan delas; adressen 0x6d är reserverad |
+| GPIO 3 | I2C SCL | Systemets I2C | Kan delas; adressen 0x6d är reserverad |
+| GPIO 6 | SPI CS | CAN FD | Egen chip select för CAN-styrkretsen |
+| GPIO 9 | SPI MISO | CAN FD | Delad SPI0-buss |
+| GPIO 10 | SPI MOSI | CAN FD | Delad SPI0-buss |
+| GPIO 11 | SPI SCK | CAN FD | Delad SPI0-buss |
+| GPIO 12 | UART TX | RS-485 | UART4 sändning |
+| GPIO 13 | UART RX | RS-485 | UART4 mottagning |
+| GPIO 24 | RS-485 EN | RS-485 | Aktiveringssignal (endast manuellt läge) |
+| GPIO 26 | CAN INT | CAN FD | Avbrottsledning för CAN-styrkretsen |
+
+### Delade gränssnitt och konflikter
+
+I2C-bussen på GPIO 2 och 3 kan delas med HAT-enheter, eftersom I2C stöder flera enheter på samma buss. HAT-kort får dock inte använda I2C-adressen 0x6d, som är reserverad för HALPI2:s systemstyrkrets. De flesta I2C-kort fungerar utan problem, men kontrollera vilka I2C-adresser de använder före installationen.
+
+SPI0-bussen som CAN FD-gränssnittet använder kan i princip delas med andra SPI-enheter, eftersom HALPI2 använder egna stift för chip select (GPIO 6) och avbrott (GPIO 26). HAT-kort som använder SPI0 med de vanliga chip select-stiften (GPIO 7 eller GPIO 8) kan samexistera med CAN-gränssnittet, men kan kräva ytterligare konfiguration med device tree-överlägg.
+
+### Att stänga av inbyggda gränssnitt
+
+Om ett HAT-kort kräver exklusiv tillgång till stift som HALPI2:s inbyggda gränssnitt upptar, kan gränssnitten stängas av med ändringar i hårdvaran. CAN FD-gränssnittet kan frigöras helt genom att lödbygeln GPIO6-CAN.CS på bärkortets undersida tas bort. Ändringen kopplar bort CAN-styrkretsen från SPI-bussen och frigör GPIO 6, 9, 10, 11 och 26 för HAT-bruk.
+
+RS-485-gränssnittet kan stängas av genom att bygeln RX Enable (i4) på bärkortet tas bort. Det hindrar RS-485-transceivern från att ta emot data och frigör GPIO 12 och 13 för andra ändamål. Om manuell styrning av sändningsaktiveringen inte behövs kan även GPIO 24 användas till annat, genom att bygeln för automatisk/manuell aktivering av RS-485 (i2) sätts i automatiskt läge.
+
+### Monteringsanvisning
+
+Börja med att stänga av systemet och koppla bort alla strömkällor. Ta bort kapslingens lock enligt anvisningen i avsnittet Åtkomst till kapslingen.
+
+Bärkort av version 0.5.0 och senare har förmonterade M2.5-gänginsatser på HAT-kortets fyra fästpunkter, vilket förenklar monteringen. På äldre kort av version 0.4.0 måste M2.5-muttrar monteras för hand. För att montera muttrarna måste bärkortet tillfälligt demonteras. Det går att göra utan att koppla bort alla kablar.
+
+För många vanliga HAT-kort passar distanser på 15 mm, men mät honlistens höjd för att säkerställa rätt avstånd. Hanlistens sockel är 2,5 mm hög, så lägg till det till honlistens höjd för att få fram rätt distanslängd.
+
+Skruva i distanserna i fästhålen, eller fäst dem med muttrar underifrån på kort av version 0.4.0. Passa in HAT-kortet mot den 40-poliga GPIO-stiftlisten och kontrollera att alla stift ligger rätt innan du trycker jämnt för att få kontakten på plats. Kortet ska sitta parallellt med bärkortet, utan synlig glipa vid GPIO-anslutningen.
+
+Fäst HAT-kortet med M2.5-skruvar eller ytterligare distanser genom kortets fästhål ned i distanserna. Skruvarna ingår inte i HALPI2 utan måste skaffas separat. Dra åt dem precis så mycket att kortet sitter stadigt, utan att kretskortet böjs.
+
+### Kabeldragning
+
+Om HAT-kortet har externa kontakter som behöver nås utifrån kapslingen bör du montera lämpliga panelkontakter i de lediga PG7-genomföringsplatserna. Då bevaras kapslingens skydd mot väder och vind samtidigt som anslutningen blir enkel att nå.
+
+### Demontering
+
+Demontering av ett HAT-kort följer monteringen i omvänd ordning. Stäng av systemet helt och koppla bort alla strömkällor innan du öppnar kapslingen. Ta bort M2.5-fästskruvarna och lyft kortet rakt upp från GPIO-stiftlisten, utan sidokrafter som kan böja stiften.
+
+Om kortet sitter fast, leta efter förbisedda skruvar eller kablar innan du tar i mer. Vissa HAT-kort med tätt sittande kontakter kan behöva vaggas försiktigt medan du drar uppåt. Vagga kortet i nord-sydlig riktning; att vagga öst-västligt riskerar att böja stiften när kontakten plötsligt släpper.
+
+### Konfiguration av programvaran
+
+Efter monteringen kan HAT-kortet behöva konfigureras i programvaran för att fungera. Många kort levereras med device tree-överlägg som måste aktiveras i Raspberry Pi:ns konfiguration. Redigera `/boot/firmware/config.txt` och lägg till de `dtoverlay`-rader som anges i kortets dokumentation.
+
+!!! quote "Relaterad information"
+    - **GPIO-stiftläge:** se [Hårdvarureferens](../technical-reference/hardware.md)
+    - **Konfiguration av programvaran:** se [Avancerad konfiguration](../software-development/advanced-config.md)
+    - **Ändringar i kapslingen:** se [Egna kontaktalternativ](#egna-kontaktalternativ)
+
+## Byte av NVMe SSD
+
+### SSD-kompatibilitet
+
+HALPI2 stöder M.2 2230–2280 NVMe SSD-enheter i vanligt enkelsidigt utförande. Kortare 2230-enheter kan vara dubbelsidiga tack vare det extra utrymmet vid den fästpunkten, men längre enheter måste vara enkelsidiga för att få plats på bärkortet.
+
+Kompatibiliteten kan bara garanteras för SSD-enheter som levereras av Hat Labs och för officiella Raspberry Pi-enheter. Om du överväger en enhet från tredje part bör du kontrollera dess kompatibilitet med Raspberry Pi 5 före köpet, genom användarrapporter och kompatibilitetslistor på nätet. Vanliga problem med inkompatibla enheter är alltför hög strömförbrukning, överhettning samt startfel eller instabilitet.
+
+### Förbereda den nya SSD-enheten
+
+Innan en ny SSD monteras i HALPI2 bör operativsystemet flashas till enheten. Det går att flasha SSD-enheten efter monteringen via CM5:ns USB Boot-kontakt (j1), men det är enklare och snabbare med en extern USB-NVMe-adapter. Flashningen beskrivs i [Programvaruguiden](./software.md).
+
+### Att stänga av systemets 3,3 V-spänning
+
+Superkondensatorerna kan hålla bärkortets 3,3 V-skena spänningssatt en avsevärd tid efter att huvudströmmen kopplats bort. Eftersom SSD-enheten matas från 3,3 V-skenan måste skenan stängas av, så att enheten säkert är spänningslös före demontering eller montering.
+
+Börja med att stänga av HALPI2 och koppla bort strömförsörjningen. Öppna kapslingen enligt anvisningen i avsnittet Åtkomst till kapslingen.
+
+Leta upp bygeln ”3.3V off” på bärkortet. Placeringen varierar med kortets version. På kort av version 0.4.0 sitter bygeln mycket nära superkondensatorerna, på deras ”södra” sida. På kort av version 0.5.0 och senare hittar du stiftlisten ”Pow.Ctrl” ”öster” om superkondensatorerna. Stiften ”3.3V off” är de två översta på listen.
+
+Flytta bygeln så att stiften ”3.3V off” kortsluts. Det stänger av 3,3 V-skenan, vilket syns genom att lysdioderna slocknar.
+
+### Demontering
+
+M.2-platsen sitter vid bärkortets södra kant. Se bilden i avsnittet [Bärkortets kontakter](#barkortets-kontakter) för att hitta M.2-kontakten märkt **g1**.
+
+Ta bort M2.5-fästskruven med en PH1-skruvmejsel. När skruven är borta fjädrar SSD-enheten upp i vinkel. Lyft enheten försiktigt i fäständen och vicka ut den ur M.2-kontakten. Håll i enhetens kanter för att inte skada komponenter eller kontakter.
+
+### Montering
+
+För in den förberedda SSD-enheten i M.2-kontakten i ungefär 30 graders vinkel och se till att skåran i enheten passar mot kontaktens styrning. Enheten ska glida in mjukt, utan att du behöver ta i. När den sitter helt på plats trycker du ned fäständen tills den ligger plant mot distansen.
+
+Fäst SSD-enheten med M2.5-skruven och en PH1-skruvmejsel. Dra åt precis så mycket att enheten hålls stadigt på plats. Den ska ligga helt plant, utan synlig böj.
+
+När SSD-enheten sitter på plats tar du bort bygeln från stiften ”3.3V off” för att koppla in 3,3 V-skenan igen. Låt bygeln sitta kvar på stiftlisten för framtida bruk.
+
+Montera ihop kapslingen enligt avsnittet Åtkomst till kapslingen.
+För konfiguration av programvaran och felsökning, se [Programvaruguiden](./software.md).
+
+!!! quote "Relaterad information"
+    - **Systemavbilder:** se [Programvaruguiden](./software.md)
+    - **Startförlopp:** se [Systemdrift](./operation.md)
+    - **Åtkomst till hårdvaran:** se [Åtkomst till kapslingen](#atkomst-till-kapslingen)
+
+## Byte av Compute Module 5
+
+### Förutsättningar
+
+Byte av Compute Module 5 kräver varsamhet, eftersom kort-till-kort-kontakterna är ömtåliga. CM5 använder två kontakter med hög täthet som lätt skadas av alltför stor kraft eller fel teknik. Demontera en befintlig modul bara när det är absolut nödvändigt, till exempel om den är trasig eller ska uppgraderas. Skador på Compute Modules monteringskontakter — på CM5 eller på bärkortet — täcks inte av garantin.
+
+Innan du börjar bör du ha värmeledande dynor till hands. I standardutförandet används en 1 mm tjock dyna på SoC:n och 2 mm tjocka dynor på RP1-kretsen och den interna strömförsörjningens komponenter. Befintliga dynor kan återanvändas om de är hela och rena.
+
+### Att komma åt Compute Module
+
+Stäng av HALPI2 och koppla bort strömkällan. Ta bort kapslingens lock enligt anvisningen i avsnittet Åtkomst till kapslingen. CM5 sitter på bärkortets undersida, så du måste först demontera bärkortet från kapslingen för att komma åt den. För att hålla reda på de många kablar som är anslutna till bärkortet rekommenderas att du tar några foton av anslutningarna innan du fortsätter.
+
+Koppla bort de kablar som hindrar dig från att lyfta bärkortet. Ta bort bärkortets fästskruvar och lyft ut kortet ur kapslingen.
+
+### Att ta bort den befintliga modulen
+
+!!! danger "Varning"
+    Om CM5-modulen lossas en kontakt i taget kan vridkrafterna slita loss kontakten från modulen. Sådana skador täcks inte av garantin.
+
+CM5 hålls fast av två kort-till-kort-kontakter som kräver varsam hantering. Använd aldrig metallverktyg för det här momentet, eftersom de kan skada kontakterna eller närliggande ytmonterade komponenter. Använd en spudger av trä eller plast, ett plektrum eller ett liknande icke ledande verktyg.
+
+Placera verktyget mitt på CM5-modulens vänstra kortsida, mellan modulen och bärkortet. Tryck bestämt nedåt i hörnen på den högra sidan. Bänd försiktigt uppåt med minimal kraft — modulen ska lossna med ett lätt klick och båda kontakterna ska släppa samtidigt.
+
+![Demontering av CM5-modulen](./unmount-cm5.jpg)
+*Demontera CM5-modulen genom att trycka nedåt i den högra kantens hörn samtidigt som du bänder uppåt mitt på den vänstra kanten. Båda kontakterna ska släppa samtidigt.*
+
+### Att montera den nya modulen
+
+Passa in den nya CM5-modulen mot bärkortets kontakter med hjälp av konturen i tryckskiktet på bärkortet. Den utritade konturen ska stämma exakt med CM5:ns mått när modulen ligger rätt vänd.
+
+När modulen är inpassad trycker du varsamt och jämnt vid kontaktlägena på båda kortsidorna. Du ska känna hur kontakterna griper med ett svagt klick. Tryck bestämt, men undvik att böja bärkortet — stöd kortet underifrån om det behövs. Båda kontakterna måste sitta helt i för att modulen ska fungera.
+
+Sätt sedan de värmeledande dynorna på CM5-modulen. De ska placeras rätt: en 1 mm dyna på huvud-SoC:n och 2 mm dynor på RP1-kretsen och strömförsörjningens komponenter. Om du återanvänder befintliga dynor, kontrollera att de är rena och rätt placerade.
+
+![Placering av värmeledande dynor på CM5](./cm5-thermal-pads-annotated.jpg)
+*Placering av de värmeledande dynorna på Compute Module 5. Använd en 1 mm tjock dyna på SoC:n (i mitten) och 2 mm tjocka dynor på RP1 och strömförsörjningens komponenter. Dynornas verkliga former och storlekar kan variera.*
+
+### Anslutning av antennen
+
+Innan du sätter tillbaka bärkortet ansluter du U.FL-antennkabeln till CM5:ns trådlösa antennkontakt. Den anslutningen går inte att komma åt när bärkortet väl är monterat. U.FL-kontakten kräver noggrann inpassning och ett bestämt tryck för att sitta rätt. Du ska känna ett tydligt knäpp när kontakten är helt på plats. Var försiktig så att du inte böjer kontaktens hölje under monteringen.
+
+### Slutlig montering
+
+Kontrollera monteringen: båda kontakterna ska sitta helt i och modulen ska ligga plant mot bärkortet utan glipor. De värmeledande dynorna ska ha kontakt med modulens värmealstrande komponenter.
+
+Placera bärkortet tillbaka i kapslingen och se till att dynorna på CM5 hamnar mot motsvarande värmeavledande ytor i kapslingens botten. Sätt tillbaka alla bärkortets fästskruvar och återanslut de kablar som kopplades bort vid demonteringen.
+
+Slutför monteringen enligt det vanliga förfarandet för att stänga kapslingen. Vid första start ska systemet känna igen den nya CM5-modulen automatiskt.
+
+!!! warning "Varning för kontakterna"
+    Kort-till-kort-kontakterna är de ömtåligaste delarna i det här momentet. Använd aldrig metallverktyg nära kontakterna, använd bara vertikal kraft vid demontering och montering, och kontrollera att inpassningen är perfekt innan du trycker. Skadade kontakter kräver i regel att bärkortet byts.
+
+!!! quote "Relaterad information"
+    - **Uppsättning av systemet efter bytet:** se [Programvaruguiden](./software.md)
+    - **Felsökning av starten:** se [Felsökning](./troubleshooting.md)
+    - **Värmehantering:** se [Hårdvarureferens](../technical-reference/hardware.md)

--- a/docs/sv/user-guide/interfaces.md
+++ b/docs/sv/user-guide/interfaces.md
@@ -1,0 +1,210 @@
+# Gränssnitt och anslutningar
+
+## CAN FD / NMEA 2000
+
+HALPI2 har ett helt isolerat [CAN FD](https://en.wikipedia.org/wiki/CAN_FD)-gränssnitt som fungerar både för marina [NMEA 2000](https://en.wikipedia.org/wiki/NMEA_2000)-nätverk och för fordons- och industritillämpningar. Gränssnittet ger snabb dataöverföring med fullständig elektrisk isolation och därmed god störningstålighet.
+
+### Gränssnittets specifikationer
+
+CAN FD-gränssnittet stöder både vanligt CAN och CAN FD. I NMEA 2000-bruk arbetar det i vanligt CAN-läge med standardhastigheten 250 kbit/s. I fordons- och industritillämpningar kan det utnyttja CAN FD:s fulla kapacitet med hastigheter upp till 8 Mbit/s.
+
+På frontpanelen sitter en Micro-C-kontakt som är kompatibel med vanligt NMEA 2000-kablage och tillhörande komponenter. Enheten kan därmed anslutas direkt till befintliga marina nätverk med vanliga T-kopplingar och stickledningar.
+
+### Strömförsörjning och belastning av nätverket
+
+Hur mycket HALPI2 belastar NMEA 2000-nätverkets strömförsörjning beror på hur den matas. I standardutförandet, med extern matning via E7T-kontakten, tar enheten ingen ström från NMEA 2000-nätverket, och dess belastningstal (LEN) är därför 0.
+
+När enheten matas från NMEA 2000-bussen måste strömuttaget begränsas till 0,9 A av den interna strömbegränsaren. Det motsvarar ett LEN-värde på 18. Anslut då enheten till nätverkets backbone nära matningspunkten, så att spänningsfallet blir litet och driften tillförlitlig.
+
+### Hårdvarukonfiguration
+
+Bärkortet har ett termineringsmotstånd på 120 Ω som kan kopplas in med en bygel. I NMEA 2000-tillämpningar ska terminering vid enheten undvikas, eftersom standarden inte tillåter det. I fordons- och industritillämpningar med punkt-till-punkt-förbindelse kan bygeln däremot sättas i.
+
+För diagnostik och felsökning har bärkortet egna RX- och TX-lysdioder som visar trafiken på nätverket. De ger omedelbar återkoppling om sändning och mottagning, vilket gör det enklare att ringa in anslutningsproblem.
+
+### Anslutning till nätverket
+
+Anslutningen till ett NMEA 2000-nätverk görs med en vanlig T-koppling (medföljer ej) på nätverkets backbone och en stickledning mellan T-kopplingen och HALPI2:s Micro-C-kontakt.
+
+### Programvaruintegration
+
+CAN-gränssnittet integreras sömlöst i Linux via ramverket SocketCAN och visas som nätverksenheten `can0`. Tack vare detta standardgränssnitt kan du använda Linux vanliga CAN-verktyg för övervakning och diagnostik. Nätverksgränssnittet är förkonfigurerat i alla HALPI2:s systemavbilder (HaLOS, OpenPlotter och Raspberry Pi OS).
+
+Integration med Signal K-servern finns i HaLOS Marine-avbilderna och i OpenPlotter: de hittar CAN-gränssnittet automatiskt och använder det för att behandla NMEA 2000-data. I HaLOS-avbilder som inte är marina kan Signal K installeras från Container Apps-butiken i Cockpit. Signal K-servern avkodar PGN-meddelanden och ger webbaserad åtkomst till nätverkets data i realtid.
+
+### Felsökning
+
+Felsökningen av nätverket börjar med RX/TX-lysdioderna på bärkortet. Vid normal drift blinkar de i takt med trafiken. Utebliven RX-aktivitet kan tyda på kabelproblem eller felaktig terminering, medan utebliven TX-aktivitet kan tyda på konflikter i nätverket eller på kablaget.
+
+Med Linux-kommandot `candump` kan du följa CAN-bussen direkt från kommandoraden. Verktyget visar detaljerad information om alla meddelanden på bussen och möjliggör en grundlig diagnostik. I sin enklaste form:
+
+```bash
+candump can0
+```
+
+Det visar alla inkommande råa CAN-meddelanden i realtid.
+
+Signal K-serverns instrumentpanel ger ytterligare övervakningsmöjligheter. Den visar NMEA 2000-datahastigheterna från CAN-gränssnittet i realtid, och med databläddraren kan du granska avkodade NMEA 2000-data.
+
+!!! quote "Relaterad information"
+    - **Konfiguration av strömförsörjningen:** se [Kom igång](../getting-started/getting-started.md#permanent-power-installation)
+    - **Uppsättning av programvaran:** se [Programvaruguiden](./software.md)
+    - **Felsökning av nätverket:** se [Felsökning](./troubleshooting.md)
+
+
+## RS-485 (NMEA 0183)
+
+HALPI2 har ett isolerat [RS-485](https://en.wikipedia.org/wiki/RS-485)-gränssnitt för seriell kommunikation med marina [NMEA 0183](https://en.wikipedia.org/wiki/NMEA_0183)[^rs422]-nätverk och industritillämpningar.
+
+[^rs422]: Strikt sett använder NMEA 0183 standarden RS-422, men RS-485 är bakåtkompatibel, så HALPI2 kan kommunicera med både RS-422- och RS-485-enheter.
+
+### Gränssnittets specifikationer
+
+RS-485-transceivern arbetar i hastigheter upp till 10 Mbit/s, även om typiska NMEA 0183-tillämpningar använder standardhastigheterna 4800 eller 38400 bit/s. Gränssnittet är galvaniskt isolerat och följer NMEA 0183-specifikationen; det skyddar HALPI2 mot jordslingor och de elektriska störningar som är vanliga i marin miljö.
+
+Det är internt kopplat till Raspberry Pi:s UART 4 och visas i Linux som `/dev/ttyAMA4`. Den här vanliga serieporten kan användas av alla program som stöder seriell kommunikation, däribland Signal K-servern, OpenCPN och egna program.
+
+### Hårdvarukonfiguration
+
+Bärkortet har egna RX- och TX-lysdioder som visar trafiken på RS-485-gränssnittet. De ger omedelbar återkoppling under installation och felsökning och gör det enkelt att se att data sänds och tas emot korrekt.
+
+Som allmänt RS-485-gränssnitt kan enheten ställas in på automatisk eller manuell sändningsaktivering. I manuellt läge styr ett GPIO-stift aktiveringssignalen, så att programvaran avgör när gränssnittet sänder och när det tar emot. Det behövs i tillämpningar med flera sändare, där gränssnittet måste vara passivt när det inte sänder. I automatiskt läge aktiverar hårdvaran signalen själv när data sänds, vilket förenklar uppsättningar med en enda sändare.
+
+RS-485-gränssnittet stöder dessutom halv duplex, så att det kan både sända och ta emot på samma ledarpar.
+
+Gränssnittet kan också stängas av helt genom hårdvarukonfiguration, om UART 4 behövs till något annat.
+
+### Kablage och anslutning
+
+RS-485-gränssnittet kräver en kabelgenomföring eller en panelkontakt, som användaren själv skaffar. Ett bra alternativ är [en SP13-panelkontakt med ledning](https://shop.hatlabs.fi/products/sp13-pigtail-connector-pair-5-pin-female-cable-plug). Gränssnittet är bakåtkompatibelt med RS-422-signaleringen i NMEA 0183 och stöder både RS-485-nätverk med flera sändare och RS-422-nätverk med en sändare och flera mottagare. Det använder balanserade differentialpar, märkta TX+/TX- och RX+/RX-.
+
+### Programvaruintegration
+
+I alla HALPI2-avbilder är RS-485-gränssnittet färdigt att använda. I HaLOS Marine-avbilderna och i OpenPlotter hittar Signal K-servern gränssnittet automatiskt och tar emot de NMEA 0183-data som sänds.
+
+I egna tillämpningar beter sig gränssnittet som en vanlig serieport i Linux. Program kan öppna `/dev/ttyAMA4` och ställa in hastighet, databitar, stoppbitar och paritet enligt den anslutna utrustningens krav. Program i Python, Node.js och C/C++ når gränssnittet med vanliga bibliotek för seriell kommunikation.
+
+### Vanliga tillämpningar
+
+Ombord ansluts RS-485-gränssnittet vanligen till GPS-mottagare, ekolod, vindmätare, AIS-transpondrar eller andra enheter som använder NMEA 0183. I industrin kan det anslutas till programmerbara styrsystem, sensorer och annan automationsutrustning som använder Modbus RTU eller andra RS-485-protokoll.
+
+Den höga hastigheten möjliggör också mindre vanliga användningar, som snabb insamling av sensordata eller egna överföringsprotokoll, vilket gör HALPI2 lämplig för forskningsfartyg och specialiserade övervakningsuppgifter.
+
+!!! quote "Relaterad information"
+    - **Konfiguration av programvaran:** se [Programvaruguiden](./software.md)
+    - **Felsökning:** se [Felsökning](./troubleshooting.md)
+
+
+## GNSS (GPS)
+
+HALPI2 stöder GNSS-mottagare i form av HAT-kort anslutna till UART0 (`/dev/ttyAMA0`). Alla GNSS-mottagare på den porten fungerar med gpsd direkt.
+
+För u-blox-mottagare (till exempel Max-M8Q) ger HaLOS Marine-avbilderna dessutom en automatisk konfiguration anpassad för marint bruk.
+
+### Automatisk konfiguration (u-blox-mottagare)
+
+I HaLOS Marine-avbilderna hittar och konfigurerar en systemd-tjänst (`configure-ublox-marine`) u-blox-mottagare automatiskt vid varje start:
+
+| Parameter | Värde |
+|:----------|:------|
+| Hastighet | 115200 bit/s (fabriksvärde: 9600) |
+| Uppdateringsfrekvens | 10 Hz (100 ms) |
+| Dynamisk modell | Sea (anpassad för marint bruk) |
+
+Konfigurationen körs vid varje start, eftersom ROM-baserade u-blox-moduler (som MAX-M8Q) saknar flashminne. Inställningarna sparas i batteribackat RAM (BBR), som kan tömmas när backupspänningen bryts — till exempel när enheten stått utan ström en längre tid. Omkonfigurationen sker obemärkt och förlänger gpsd:s start med ungefär 2 sekunder.
+
+Om ingen mottagare hittas avslutas tjänsten utan meddelande. Ett nyinstallerat GNSS-HAT-kort konfigureras automatiskt vid nästa omstart.
+
+### Åtkomst till data
+
+GPS-data tillhandahålls av [gpsd](https://gpsd.io/) på TCP-port 2947. I HaLOS Marine-avbilderna ansluter Signal K automatiskt till gpsd — ingen ytterligare konfiguration behövs.
+
+För diagnostik finns gpsd:s vanliga kommandoradsverktyg:
+
+```bash
+# Monitor GPS data in real-time
+gpsmon
+
+# Output raw NMEA 0183 sentences
+gpspipe -r
+```
+
+### Andra avbilder än HaLOS
+
+I Raspberry Pi OS eller andra operativsystem installerar och konfigurerar du gpsd för hand:
+
+```bash
+sudo apt install gpsd gpsd-clients
+```
+
+Redigera `/etc/default/gpsd` och sätt `DEVICES="/dev/ttyAMA0"`, och starta sedan om tjänsten. Mottagaren arbetar med sina fabriksinställningar (9600 bit/s, 1 Hz) tills den konfigurerats med `ubxtool` från paketet `gpsd-clients`.
+
+!!! quote "Relaterad information"
+    - **gpsd i HaLOS:** se [HaLOS GPS-dokumentation](https://docs.halos.fi/user-guide/gps/)
+    - **Uppsättning av programvaran:** se [Programvaruguiden](./software.md)
+
+
+## Ethernet
+
+HALPI2 har ett gigabit-ethernetgränssnitt som ger snabb nätverksanslutning för dataöverföring, fjärråtkomst och anslutning till nätverk ombord. Ethernetporten på bärkortet är en vanlig RJ45-kontakt. Den är utförd till en panelkontakt dit en extern ethernetkabel kan anslutas.
+
+## USB
+
+HALPI2 har totalt fyra USB 3.0-portar av typ A för snabb anslutning av olika kringenheter. En port går direkt till CM5:ns USB 3.0-gränssnitt, medan de tre övriga går via en USB 3-hubb på kortet. I standardutförandet är två portar utförda till frontpanelen och två finns på bärkortet för interna anslutningar.
+
+## HDMI
+
+HALPI2 har två HDMI 2.0-portar (HDMI0 och HDMI1) för videoutgång. På bärkortet finns FFC-kontakter (böjlig flatkabel) för båda portarna. De är utförda till frontpanelen med specialtillverkade FFC-kablar. Kontakterna på frontpanelen är vanliga HDMI Type A-kontakter.
+
+HALPI2:s HDMI-utgång klarar tillförlitligt två Full HD-videoströmmar (1080p). 4K-utgång kan fungera, men garanteras inte.
+
+## MIPI (CSI/DSI)
+
+Bärkortet har två MIPI CSI/DSI-kontakter för kameror och skärmar. Kontakterna är 22-poliga FFC-kontakter (böjlig flatkabel) med delningen 0,5 mm. De ska fungera som de är med nyare Raspberry Pi-kompatibla kameror och skärmar.
+
+Av täthetsskäl bör FFC-kablar bara användas för interna anslutningar.
+
+## Externa knappar
+
+HALPI2:s bärkort har en 2×3-polig stiftlist för anslutning av externa knappar. Kapslingen har inga inbyggda knappar, vilket låter användaren välja placering och typ efter egna behov.
+
+### Knappanslutningens stiftläge
+
+Bärkortet har en 6-polig stiftlist med tre märkta knappfunktioner:
+
+| Märkning | Funktion | Beskrivning |
+|:---------|:---------|:------------|
+| Reset | Reset av styrkretsen | Hårdvarureset (RP2040:s RUN-stift) |
+| Power | Raspberry Pi:s strömknapp | CM5:ns strömknapp (ingången PWR_BUT) |
+| User | Konfigurerbar av användaren | Användardefinierad händelse (ännu inte implementerad) |
+
+Varje knapp använder två stift: ett för signalen och ett för jord. Använd slutande (NO) momentana tryckknappar som förbinder signalstiftet med jord när de trycks in.
+
+### Knapparnas funktioner
+
+**Reset-knappen:**
+Reset-knappen utför en hårdvarureset genom att dra RP2040:s RUN-stift mot jord. Det återställer hela systemet: styrkretsen, CM5 och alla anslutna kringenheter. Knappen är särskilt användbar i nödlägen, när avstängning via programvaran har misslyckats och systemet inte längre svarar.
+
+**Power-knappen:**
+Power-knappen är kopplad direkt till CM5:ns strömknappsingång och fungerar precis som knappen på en Raspberry Pi 5. Ett dubbelklick begär en kontrollerad avstängning, så att operativsystemet hinner stänga program och avmontera filsystem innan spänningen bryts. Ett långt tryck tvingar fram omedelbar avstängning och bör bara användas när systemet inte svarar.
+
+**User-knappen:**
+Användarknappens funktion väntar fortfarande på implementation i programvaran och blir konfigurerbar i kommande firmwareversioner. När den är på plats är knappen avsedd för egna åtgärder och tillämpningsspecifika utlösare, där användaren själv bestämmer beteendet.
+
+### Montering av knappar
+
+#### Direkt montering i kapslingen
+
+För direkt montering i HALPI2:s kapsling använder du de färdiga hålen på 6 mm eller 13 mm. Ta först bort motsvarande blindpluggar och montera en vattentät knapp som passar hålets diameter. Anslut knappen till bärkortets stiftlist med en lämplig kabel och se till att dragavlastningen och tätningen vid genomföringen blir ordentlig.
+
+#### Montering på en separat panel
+
+När knapparna monteras på en separat manöverpanel väljer du en plats som är lätt att nå och som behåller väderbeständigheten. Använd kabelgenomföringar vid kabelinföringarna och anslut knapparna med en förlängningskabel med ledare på 22–26 AWG. Håll den totala kabellängden under 3 meter för att bevara signalkvaliteten. I fuktiga eller tuffa miljöer använder du vattentäta kontakter vid skarvarna för att säkra en tillförlitlig drift över tid.
+
+#### Anslutning
+
+Alla knappanslutningar till bärkortet bör använda honkontakter med delningen 2,54 mm. Se till att stiften ligger rätt och att anslutningen sitter stadigt, så att kontaktproblem inte uppstår under drift.
+
+!!! quote "Relaterad information"
+    - **Strömhantering:** se [Strömhantering och avstängning](./operation.md#power-management-and-shutdown-procedures)
+    - **Åtkomst till hårdvaran:** se [Hårdvaruguiden](./hardware.md)

--- a/docs/sv/user-guide/interfaces.md
+++ b/docs/sv/user-guide/interfaces.md
@@ -1,3 +1,7 @@
+---
+translated_from: da8aa35c462e57bc7c0b00d50046a1df518e97dd
+---
+
 # Gränssnitt och anslutningar
 
 ## CAN FD / NMEA 2000
@@ -47,7 +51,7 @@ Det visar alla inkommande råa CAN-meddelanden i realtid.
 Signal K-serverns instrumentpanel ger ytterligare övervakningsmöjligheter. Den visar NMEA 2000-datahastigheterna från CAN-gränssnittet i realtid, och med databläddraren kan du granska avkodade NMEA 2000-data.
 
 !!! quote "Relaterad information"
-    - **Konfiguration av strömförsörjningen:** se [Kom igång](../getting-started/getting-started.md#permanent-power-installation)
+    - **Konfiguration av strömförsörjningen:** se [Kom igång](../getting-started/getting-started.md#permanent-stromanslutning)
     - **Uppsättning av programvaran:** se [Programvaruguiden](./software.md)
     - **Felsökning av nätverket:** se [Felsökning](./troubleshooting.md)
 
@@ -206,5 +210,5 @@ När knapparna monteras på en separat manöverpanel väljer du en plats som är
 Alla knappanslutningar till bärkortet bör använda honkontakter med delningen 2,54 mm. Se till att stiften ligger rätt och att anslutningen sitter stadigt, så att kontaktproblem inte uppstår under drift.
 
 !!! quote "Relaterad information"
-    - **Strömhantering:** se [Strömhantering och avstängning](./operation.md#power-management-and-shutdown-procedures)
+    - **Strömhantering:** se [Strömhantering och avstängning](./operation.md#stromhantering-och-avstangning)
     - **Åtkomst till hårdvaran:** se [Hårdvaruguiden](./hardware.md)

--- a/docs/sv/user-guide/operation.md
+++ b/docs/sv/user-guide/operation.md
@@ -94,7 +94,7 @@ Sololäget gäller:
 - på operativsystem som saknar daemonen;
 - när daemonen har kraschat eller slutat svara.
 
-!!! tip "Solulägets tillförlitlighet"
+!!! tip "Sololägets tillförlitlighet"
     Sololäget ger ett nödvändigt skydd men är mindre tillförlitligt än co-op-läget. Styrkretsen begär avstängning med simulerade knapptryck, vilket kanske inte fungerar om systemet har hängt sig.
 
 ### Co-op-läge

--- a/docs/sv/user-guide/operation.md
+++ b/docs/sv/user-guide/operation.md
@@ -1,3 +1,7 @@
+---
+translated_from: 3ad6bd291105f72d9e440ca46e96fe9fa085e02c
+---
+
 # Systemdrift
 
 ## Status-LED:ar

--- a/docs/sv/user-guide/operation.md
+++ b/docs/sv/user-guide/operation.md
@@ -1,0 +1,208 @@
+# Systemdrift
+
+## Status-LED:ar
+
+HALPI2 har fem RGB-lysdioder som visar systemets och strömförsörjningens tillstånd.
+
+### Snabbguide till lysdioderna
+
+| LED-mönster | Färg | Betydelse |
+|-------------|------|-----------|
+| LED 5 lyser fast | Röd | Spänning på, väntar på laddning |
+| Successiv fyllning | Röd | Superkondensatorerna laddas |
+| Regnbåge med färgväxling | Flerfärgad | CM5 startade inte |
+| Spänningsstapel | Gul | Drift i sololäge |
+| Spänningsstapel | Grön | Drift i co-op-läge |
+| Spänningsstapel | Orange | Backupström aktiv (solo) |
+| Spänningsstapel | Mörkgrön | Backupström aktiv (co-op) |
+| Alla blinkar | Röd | Överspänning i superkondensatorerna |
+| Alla lyser fast | Röd | Watchdog löste ut |
+| Spänningsstapel | Violett | Avstängning pågår |
+| Alla lyser fast | Blå | Övergång till vänteläge pågår |
+| Alla lyser fast | Dämpad röd | Vänteläge |
+| Alla släckta | — | Systemet avstängt |
+
+### Spänningsindikering för superkondensatorerna
+
+Under drift fungerar lysdioderna som spänningsmätare och visar superkondensatorernas laddningsnivå:
+
+- **LED 1**: 5,0–6,0 V
+- **LED 2**: 6,0–7,0 V
+- **LED 3**: 7,0–8,0 V
+- **LED 4**: 8,0–9,0 V
+- **LED 5**: 9,0–10,0 V
+
+## Strömhantering och avstängning
+
+HALPI2 har en strömförsörjning som är konstruerad för att klara spänningstoppar, störningar och korta avbrott.
+
+### Översikt över strömförsörjningen
+
+HALPI2:s strömhantering består av:
+
+- **En strömförsörjning med brett område** (ingång 11–32 V DC, skydd upp till 100 V DC)
+- **Backup med superkondensatorer** för kontrollerad avstängning vid spänningsbortfall
+- **Strömbegränsning** (0,9 A eller 2,5 A, valbart)
+- **Detektering av spänningsbortfall** och automatisk start av avstängningen
+- **Övervakning av inspänning och inström**
+
+Systemet arbetar i två lägen: sololäge och co-op-läge.
+
+### Sololäge
+
+Sololäget ger en grundläggande självständig drift när HALPI-daemonen inte körs. Styrkretsen arbetar på egen hand, utan kontakt med programvaran.
+
+#### Sololägets egenskaper
+
+- **Kräver ingen kommunikation med programvaran**
+- **Grundläggande skydd mot spänningsbortfall** — övervakar inspänningen och reagerar på avbrott
+- **Automatisk avstängning via simulerade tryck på strömknappen**
+- **Begränsade möjligheter till övervakning och konfiguration**
+
+#### Spänningsbortfall och avstängning i sololäge
+
+**Detektering av spänningsbortfall:**
+Styrkretsen övervakar inspänningen och upptäcker avbrott. En avbrottstimer (5 sekunder som standard) hindrar avstängning vid korta störningar.
+
+**Automatisk avstängningssekvens:**
+
+1. **Styrkretsen upptäcker spänningsbortfallet**
+2. **Avbrottstimern startar**, för att skilja en kort störning från ett verkligt bortfall
+3. **Simulerade tryck på strömknappen** — styrkretsen skickar ett dubbeltryck till Compute Module
+4. **Operativsystemet reagerar** och påbörjar en kontrollerad avstängning
+5. **Superkondensatorerna håller uppe spänningen** (normalt 30 till 60 sekunder)
+6. **Skydd med 60 sekunders tidsgräns** — framtvingad avstängning om den kontrollerade avstängningen misslyckas
+7. **Systemet förblir avstängt** tills spänningen återvänder
+8. **Automatisk omstart** när spänningen är tillbaka
+
+**Manuell avstängning i sololäge:**
+
+- Operativsystemet stängs av på vanligt sätt
+- Systemet startar om automatiskt efter 5 sekunder om inspänningen fortfarande finns
+- För permanent avstängning kopplar du bort inspänningen efter att ha startat den kontrollerade avstängningen
+
+#### När sololäget är aktivt
+
+Sololäget gäller:
+
+- allra först vid start, innan HALPI-daemonen har startat;
+- om HALPI-daemonen inte startar eller är avstängd;
+- på operativsystem som saknar daemonen;
+- när daemonen har kraschat eller slutat svara.
+
+!!! tip "Solulägets tillförlitlighet"
+    Sololäget ger ett nödvändigt skydd men är mindre tillförlitligt än co-op-läget. Styrkretsen begär avstängning med simulerade knapptryck, vilket kanske inte fungerar om systemet har hängt sig.
+
+### Co-op-läge
+
+Co-op-läget ger full strömhantering när HALPI-daemonen körs och kommunicerar med styrkretsen.
+
+#### Co-op-lägets funktioner
+
+- **Direkt kommunikation med programvaran** — utbyte av data i realtid mellan styrkrets och daemon
+- **Skydd med watchdog** — en tidsgräns på 30 sekunder säkerställer systemets stabilitet
+- **Konfigurerbart avstängningsbeteende** — tider och kommandon går att justera
+- **Övervakning i realtid** — omfattande uppföljning av strömförsörjningens värden
+- **Avancerade konfigurationsmöjligheter**
+
+#### Spänningsbortfall och avstängning i co-op-läge
+
+**Detektering av spänningsbortfall:**
+Styrkretsen övervakar inspänningen och rapporterar händelser direkt till HALPI-daemonen. Den konfigurerbara avbrottstimern (5 sekunder som standard) tillåter korta avbrott utan att avstängningen startar.
+
+**Automatisk avstängningssekvens:**
+
+1. **Styrkretsen upptäcker spänningsbortfallet** och meddelar HALPI-daemonen
+2. **Bedömning av avbrottstimern** — daemonen avgör om avbrottet överskrider tröskeln
+3. **Avstängningskommandot körs** — daemonen kör det inställda kommandot (som standard `/sbin/poweroff`)
+4. **Kontrollerad avstängning av operativsystemet** — program avslutas och filsystem avmonteras säkert
+5. **Backupströmmen från superkondensatorerna** räcker under hela avstängningen
+6. **Styrkretsen följer förloppet** — den märker när Compute Module stängs av
+7. **5 V-skenan stängs av** när avstängningen är klar
+8. **Systemet förblir avstängt** tills inspänningen återvänder
+9. **Hantering av omstart** — beroende på konfigurationen startar systemet om automatiskt eller förblir avstängt
+
+**Manuell avstängning i co-op-läge:**
+
+- En avstängning som startas från programvaran sker kontrollerat
+- Systemet startar om automatiskt efter 5 sekunder om inspänningen fortfarande finns
+- För att förhindra automatisk omstart kopplar du bort spänningen eller sätter `auto_restart` till `false`
+
+#### Skydd med watchdog
+
+Co-op-läget innehåller en watchdog:
+
+- **Kommunikationsgräns på 30 sekunder** — daemonen måste höra av sig till styrkretsen regelbundet
+- **Automatisk återhämtning** — systemet startar om om kommunikationen upphör
+- **Skydd mot programvarufel** — säkerställer återhämtning efter att daemonen kraschat eller systemet hängt sig
+- **”Mata watchdogen”** — daemonen skickar regelbundna statusmeddelanden som nollställer timern
+
+#### När co-op-läget är aktivt
+
+Co-op-läget gäller när:
+
+- HALPI-daemonen körs och fungerar normalt;
+- kommunikationen mellan daemon och styrkrets är upprättad;
+- systemet kör ett operativsystem som stöds;
+- alla övervaknings- och styrfunktioner är tillgängliga.
+
+!!! info "Kontrollera co-op-läget"
+    Daemonens status: `systemctl status halpid`
+
+    Styrkretsens tillstånd: `halpi status`
+
+    Mer om kommandot `halpi` finns i [Programvaruguiden](./software.md#halpi-daemon-halpid).
+
+### Backupström och kondensatorsystem
+
+Båda lägena bygger på superkondensatorerna för att säkra en kontrollerad avstängning:
+
+**Backupströmmens varaktighet:**
+
+- Superkondensatorerna ger 30 till 60 sekunders backuptid
+- Tiden beror på systemets belastning och anslutna kringenheter
+- Den räcker för att stänga filsystemet och avsluta processer säkert
+- Den är inte avsedd för fortsatt drift under längre avbrott
+
+**Laddningsegenskaper:**
+
+- Laddningstid: 25 sekunder vid strömbegränsning 0,9 A
+- Laddningstid: 9 sekunder vid strömbegränsning 2,5 A
+- Laddningsförloppet syns genom att lysdioderna fylls (rött fyllningsmönster)
+
+!!! warning "Begränsning i skyddet mot spänningsbortfall"
+    Systemet med superkondensatorer är avsett för kontrollerad avstängning, inte för fortsatt drift. Lita inte på det vid längre strömavbrott.
+
+### Att tänka på vid manuell avstängning
+
+HALPI2 prioriterar automatisk drift och återhämtning, vilket påverkar hur en manuell avstängning beter sig.
+
+#### Automatisk omstart
+
+Som standard startar HALPI2 om efter en manuell avstängning om inspänningen fortfarande finns:
+
+- En manuell avstängning stänger av operativsystemet på vanligt sätt
+- Efter avslutad avstängning följer en väntetid på 5 sekunder
+- Systemet startar om automatiskt för att förbli tillgängligt
+- Det säkerställer återhämtning efter en avstängning av misstag
+
+#### Så stänger du av enheten permanent
+
+Det finns två sätt:
+
+**Koppla bort spänningen:**
+
+1. Starta en kontrollerad avstängning från programvaran
+2. Vänta tills avstängningen är klar (lysdioderna släcks)
+3. Koppla bort inspänningen för att förhindra automatisk omstart
+
+**Ändra konfigurationen:**
+
+1. Stäng av automatisk omstart: `halpi config set auto_restart false`
+2. Starta avstängningen från programvaran
+3. Systemet förblir avstängt efter avslutad avstängning
+
+**Vänteläge (kommande):**
+
+!!! info "Funktionens status"
+    Vänteläget planeras till kommande firmwareversioner. Det kommer att göra det möjligt att stänga av Compute Module medan HALPI2:s styrkrets förblir aktiv och väntar på väckningshändelser.

--- a/docs/sv/user-guide/software.md
+++ b/docs/sv/user-guide/software.md
@@ -1,0 +1,389 @@
+---
+translated_from: a428b6a7e1ca303e0571592a86d0cc6a3db97a83
+---
+
+# Programvaruguide
+
+## Systemavbilder
+
+Hat Labs tillhandahåller färdiga avbilder för HALPI2. Alla innehåller den konfiguration och de anpassningar HALPI2-hårdvaran kräver: CAN (NMEA 2000) som nätverksenheten `can0`, RS-485 (NMEA 0183) som `/dev/ttyAMA4` samt paketet `halpi2-firmware`.
+
+### HaLOS (standard)
+
+[HaLOS](https://docs.halos.fi) är en containerbaserad Linux-distribution avsedd för marina och industriella tillämpningar. Den erbjuder ett webbgränssnitt för systemadministration, apphantering och övervakning — utan skärm, tangentbord eller VNC.
+
+**Varianter av avbilden:**
+
+| Avbild | Beskrivning |
+|:-------|:------------|
+| Halos-HALPI2 | Basavbild utan skärm, med Cockpit och containerhantering |
+| Halos-HALPI2-Desktop | Basavbild med Raspberry Pi Desktop |
+| Halos-HALPI2-Marine | Utan skärm, med marina appar (Signal K, Grafana, InfluxDB, AvNav) |
+| Halos-HALPI2-Desktop-Marine | Skrivbord med marina appar |
+
+Hämta HaLOS-avbilderna från [HaLOS releasesida](https://github.com/halos-org/halos-pi-gen/releases/latest). Utförlig dokumentation finns på [docs.halos.fi](https://docs.halos.fi).
+
+### OpenPlotter
+
+OpenPlotter är en avbild baserad på Raspberry Pi OS med tillägg för marina tillämpningar. Den ger en klassisk skrivbordsmiljö med VNC-fjärråtkomst och har Signal K och OpenCPN förinstallerade.
+
+Om du inte använder skärm, tangentbord och mus med HALPI2 kan du ansluta antingen med en ethernetkabel eller via WiFi-accesspunkten (`OpenPlotter`, lösenord `12345678`).
+
+I båda fallen når du HALPI2-datorn med VNC eller SSH. För VNC behöver du RealVNC:s [VNC Viewer](https://www.realvnc.com/en/connect/download/viewer/).
+
+Eftersom både accesspunkten och standardanvändaren har standardlösenord är det nödvändigt att byta dem omedelbart efter första start. Hur det går till beskrivs i [OpenPlotters dokumentation](https://openplotter.readthedocs.io/latest/getting_started/first_steps.html).
+
+Hämta OpenPlotter-avbilderna från [GitHub](https://github.com/hatlabs/openplotter-halpi/releases).
+
+### Raspberry Pi OS och Raspberry Pi OS Lite
+
+Om du föredrar vanliga Raspberry Pi OS kan du hämta den senaste avbilden med HALPI2-stöd från [GitHub-repositoriet](https://github.com/hatlabs/openplotter-halpi/releases). Flasha avbilden till SSD-enheten med Raspberry Pi Imager. Under flashningen kan du göra anpassningar, som att sätta värdnamn, aktivera SSH och ställa in WiFi.
+
+Om du hoppar över anpassningarna behöver du en skärm och ett tangentbord anslutna till HALPI2 för den första konfigurationen. Vid första start får du ange användarnamn och lösenord.
+
+
+## Flasha en systemavbild till SSD-enheten
+
+Det finns två sätt att flasha en systemavbild till HALPI2:s NVMe SSD: ta ut SSD-enheten och använda en USB-NVMe-adapter, eller flasha direkt på HALPI2. USB-NVMe-adaptern rekommenderas för enkelhetens skull — sådana adaptrar finns billigt på nätet och förfarandet är okomplicerat.
+
+### Flasha med en USB-NVMe-adapter
+
+Börja med att ta ut NVMe SSD-enheten ur HALPI2 enligt anvisningen i [Hårdvaruguiden](./hardware.md#byte-av-nvme-ssd). Hämta sedan en HALPI2-kompatibel avbild — antingen en [HaLOS-avbild](https://github.com/halos-org/halos-pi-gen/releases/latest) eller en [OpenPlotter- eller Raspberry Pi OS-avbild](https://github.com/hatlabs/openplotter-halpi/releases) — och se till att välja den som passar din användning.
+
+Sätt in SSD-enheten i USB-NVMe-adaptern och anslut den till din dator. Flasha den hämtade avbilden till NVMe SSD-enheten med Raspberry Pi Imager. Om du flashar en Raspberry Pi OS-avbild kan du redigera och tillämpa systemets anpassningsinställningar under flashningen. Utan dessa anpassningar behöver du ett USB-tangentbord och en mus anslutna till HALPI2 för den första konfigurationen efter installationen.
+
+När du använder HaLOS-avbilder ska anpassningsinställningarna **inte** tillämpas under flashningen. HaLOS konfigureras efter start via sitt webbgränssnitt.
+
+På samma sätt ska anpassningsinställningarna **inte** tillämpas för OpenPlotter-avbilden. Konfigurationen görs efter första start med Raspberry Pi:s och OpenPlotters egna verktyg.
+
+När flashningen är klar kopplar du bort adaptern och tar ut SSD-enheten. Sätt tillbaka den i HALPI2 enligt monteringsanvisningen i Hårdvaruguiden och stäng kapslingen enligt samma guide.
+
+### Flasha direkt på HALPI2
+
+Alternativt kan du flasha systemavbilden direkt på HALPI2 utan att ta ut SSD-enheten. Detta följer det vanliga förfarandet för att flasha en Compute Module, som beskrivs i [Raspberry Pi:s dokumentation](https://www.raspberrypi.com/documentation/computers/compute-module.html#flash-compute-module-emmc). Anvisningarna där gäller kortet CM5 IO Board, men förfarandet är likartat på HALPI2.
+
+**Förutsättningar.** Installera verktyget `rpiboot` från Raspberry Pi:s [`usbboot`-repositorium](https://github.com/raspberrypi/usbboot). På Linux och macOS bygger och installerar du det från källkoden enligt repositoriets README; på Windows installerar du Raspberry Pi Imager eller det fristående installationsprogrammet för `rpiboot` som är länkat från samma sida.
+
+Så förbereder du HALPI2 för flashning via USB:
+
+1. Stäng av systemet helt och öppna kapslingens lock enligt anvisningen i [Hårdvaruguiden](./hardware.md#atkomst-till-kapslingen).
+2. Leta upp USB-C-kontakten märkt ”USB Boot” till höger om HAT-området på bärkortet och ställ startlägesomkopplaren bredvid i läget ”Abnormal”. (Någon lysdiodåterkoppling finns ännu inte — enheten är spänningslös.)
+3. Anslut en USB-kabel mellan din dator och USB Boot-kontakten på HALPI2 och slå på enheten igen. En bärnstensfärgad lysdiod tänds nu bredvid omkopplaren och bekräftar USB-startläget.
+4. Kör `rpiboot` på din dator. Verktyget hittar HALPI2 och läser in masslagringsfirmwaren, varefter HALPI2 visas som en USB-masslagringsenhet.
+5. När `rpiboot` är klart och masslagringsenheten dyker upp ställer du tillbaka startlägesomkopplaren i läget ”Normal”. Det avbryter inte flashningen och gör att HALPI2 startar normalt från den nyss flashade avbilden efter nästa strömcykel. Om omkopplaren står kvar på ”Abnormal” går enheten in i USB-startläge igen vid nästa start i stället för att starta det nya systemet.
+6. Flasha systemavbilden med Raspberry Pi Imager (eller ett annat verktyg som kan skriva till en blockenhet) till den nya masslagringsenheten.
+7. När flashningen är klar kopplar du bort USB-kabeln, bryter och återansluter strömmen till HALPI2 och stänger kapslingen.
+
+!!! tip "Starta om utan att dra ur strömmen"
+    När kapslingen redan är öppen är det snabbaste sättet att starta om HALPI2 att kortvarigt kortsluta de två nedersta stiften på knappanslutningen bredvid USB-C-uttaget. Att röra vid båda stiften samtidigt med metallhöljet på en USB-C-kontakt fungerar bra och är ofarligt.
+
+## Första konfigurationen av systemet
+
+När HALPI2 har flashats och startats för första gången krävs några steg för säker och korrekt drift.
+
+### Konfiguration av HaLOS
+
+HaLOS konfigureras helt via sitt webbgränssnitt. Efter första start når du Cockpit på `https://halos.local:9090/` och instrumentpanelen på `https://halos.local/`. Byt standardlösenorden omedelbart — se guiden [Kom igång](../getting-started/getting-started.md#konfiguration-vid-forsta-start) och [HaLOS dokumentation](https://docs.halos.fi/getting-started/first-boot/).
+
+### Konfiguration av OpenPlotter
+
+Med OpenPlotter-avbilden startar systemet med standardlösenord både för WiFi-accesspunkten och för standardanvändarkontot. Av säkerhetsskäl är det nödvändigt att byta dem omedelbart efter första start.
+
+Byte av lösenord och den första konfigurationen beskrivs i guiden [Kom igång](../getting-started/getting-started.md#konfiguration-vid-forsta-start) och i [OpenPlotters dokumentation](https://openplotter.readthedocs.io/latest/getting_started/first_steps.html).
+
+### Konfiguration av Raspberry Pi OS
+
+Om du har valt vanliga Raspberry Pi OS i stället för OpenPlotter följer du Raspberry Pi:s vanliga konfigurationsflöde som visas vid första start. Guiden hjälper dig att skapa användarkonton, sätta lösenord, ställa in WiFi och aktivera nödvändiga tjänster som SSH för fjärråtkomst.
+
+Under den första konfigurationen bör du också ställa in tidszon, tangentbordslayout och andra regionala inställningar så att de passar din miljö. Raspberry Pi:s konfigurationsverktyg (`raspi-config`) ger tillgång till fler systeminställningar som kan ändras efteråt.
+
+## Fjärråtkomst
+
+HALPI2 stöder flera sätt att komma åt systemet på distans, så att du kan övervaka och styra det utan fysisk åtkomst till enheten. Det är särskilt värdefullt när HALPI2 är monterad utan skärm på ett svåråtkomligt ställe.
+
+### Webbåtkomst (HaLOS)
+
+HaLOS ger ett komplett webbaserat administrationsgränssnitt utan extra programvara:
+
+- **Instrumentpanel** (`https://halos.local/`): Homarr-instrumentpanelen ger tillgång till alla installerade appar, däribland Signal K, Grafana och andra marina appar.
+- **Cockpit** (`https://halos.local:9090/`): systemadministration med terminalåtkomst, programvaruuppdateringar, nätverkskonfiguration och hantering av containerappar.
+
+### SSH (Secure Shell)
+
+SSH ger säker kommandoradsåtkomst till HALPI2, så att du kan köra kommandon, överföra filer och sköta systemadministration på distans. SSH är aktiverat som standard i HaLOS-avbilder utan skärm och i OpenPlotter. I HaLOS Desktop-varianterna och i Raspberry Pi OS aktiverar du det med `raspi-config`.
+
+För att ansluta med SSH använder du en SSH-klient, till exempel den inbyggda terminalen i macOS och Linux eller ett program som PuTTY i Windows. Grundkommandot är:
+
+```bash
+ssh username@halpi2-ip-address
+```
+
+SSH-anslutningar är krypterade och säkra, och lämpar sig därför även för publika nät när autentiseringen är rätt uppsatt. De kräver dessutom mycket lite bandbredd, vilket gör dem idealiska för fjärråtkomst över långsamma förbindelser med hög fördröjning.
+
+### VNC (Virtual Network Computing)
+
+!!! note
+    VNC gäller endast avbilderna OpenPlotter och Raspberry Pi OS Desktop. HaLOS använder webbåtkomst i stället — se ovan.
+
+VNC ger fjärråtkomst till HALPI2:s grafiska gränssnitt, så att du kan använda skrivbordet som om du satt vid enheten. VNC är förinstallerat och förkonfigurerat i OpenPlotter-avbilderna. I en Raspberry Pi OS-installation aktiverar du det med konfigurationsverktyget `raspi-config`.
+
+För att nå HALPI2:s skrivbord på distans använder du RealVNC:s [VNC Viewer](https://www.realvnc.com/en/connect/download/viewer/), som finns för Windows, macOS, Linux, iOS och Android. VNC fungerar bra i lokala nät och utan internetuppkoppling, vilket gör det lämpligt för båtinstallationer där internet kan vara begränsat eller saknas.
+
+För fjärråtkomst över internet kräver VNC extra nätverkskonfiguration, som portvidarebefordran eller VPN, eftersom protokollet inte i sig tar sig igenom brandväggar och NAT-enheter.
+
+### Raspberry Pi Connect
+
+Raspberry Pi Connect erbjuder ett modernt webbaserat sätt att nå skrivbordet på distans: du ansluter med en vanlig webbläsare, utan att installera någon extra programvara. Tjänsten tar sig automatiskt igenom brandväggar och NAT, vilket gör den särskilt lämplig för fjärråtkomst över internet utan komplicerad nätverkskonfiguration.
+
+Till skillnad från VNC sköter Raspberry Pi Connect nätverksdetaljerna själv och ger enkel åtkomst varhelst det finns internet. Den kräver dock att HALPI2 själv har en aktiv internetuppkoppling.
+
+## Programvaruuppdateringar
+
+Regelbundna uppdateringar rekommenderas för att bevara systemets prestanda och säkerhet.
+
+### Uppdateringar i HaLOS
+
+I HaLOS uppdateras systempaketen (inklusive HALPI2:s firmware) via Cockpit eller från kommandoraden med `apt`. Containerbaserade appar (Signal K, Grafana med flera) uppdateras via Container Apps-vyn i Cockpit, som letar efter nya versioner av containeravbilderna.
+
+### Uppdateringar från kommandoraden (alla avbilder)
+
+Det mest tillförlitliga sättet är kommandoraden. Öppna en terminal och kör:
+
+```bash
+sudo apt update
+sudo apt upgrade
+```
+
+Det första kommandot (`apt update`) uppdaterar paketdatabasen med de senaste tillgängliga versionerna, och det andra (`apt upgrade`) hämtar och installerar alla tillgängliga uppdateringar. Det uppdaterar samtliga installerade paket, inklusive grundsystemet Raspberry Pi OS, OpenPlotters komponenter och HALPI2:s egen programvara.
+
+Under uppdateringen kan du bli ombedd att bekräfta installationen av vissa paket eller omstart av tjänster. Det är i regel säkert att godta, om du inte har särskilda skäl att avstå.
+
+### Grafiska uppdateringar
+
+För dig som föredrar ett grafiskt gränssnitt visar skrivbordet en avisering när uppdateringar finns. En nedladdningsikon dyker upp i aktivitetsfältets övre högra hörn när uppdateringar är redo att installeras. Ett klick på ikonen öppnar uppdateringshanteraren, där du kan gå igenom och installera de tillgängliga uppdateringarna.
+
+## Firmwareuppdateringar
+
+HALPI2:s styrkretsfirmware uppdateras via Raspberry Pi OS vanliga uppdateringsflöde, vilket gör det till en integrerad och friktionsfri åtgärd. Regelbundna firmwareuppdateringar är viktiga för prestanda, för nya funktioner och för kompatibiliteten med programvara som utvecklas.
+
+### Automatiska firmwareuppdateringar
+
+Firmwareuppdateringar distribueras via det vanliga systemuppdateringsflödet, som Debian-paket i ett APT-paketförråd. För att söka efter och installera dem öppnar du en terminal och kör:
+
+```bash
+sudo apt update
+sudo apt upgrade
+```
+
+När ny HALPI2-firmware finns hämtas och installeras den automatiskt som en del av uppdateringen. Systemet meddelar dig om firmwareuppdateringar ingår bland de tillgängliga paketen.
+
+När firmwarepaketet har uppdaterats måste systemet startas om på rätt sätt för att ändringarna ska träda i kraft. Använd avstängningskommandot för att säkerställa en fullständig strömcykel:
+
+```bash
+sudo shutdown -h now
+```
+
+**Viktigt:** En vanlig omstart räcker inte för firmwareuppdateringar. En fullständig avstängning följd av start krävs, eftersom det är då styrkretsen startar om och tar den nya firmwaren i bruk. Styrkretsens firmware uppdateras bara vid påslagning.
+
+### Firmwarens säkerhetsfunktioner
+
+HALPI2 har inbyggda skydd mot skadad firmware. Om enheten startas om inom 30 sekunder efter en firmwareuppdatering återgår systemet automatiskt till den föregående firmwareversionen. Det skyddar mot problematiska uppdateringar som annars kunde hindra normal drift.
+
+### Installera firmware manuellt
+
+För erfarna användare eller i vissa felsökningssituationer kan firmwaren installeras manuellt med kommandoradsverktyget HALPI. Firmwarefilerna ligger i katalogen `/usr/share/halpi2-firmware/` och kan flashas direkt:
+
+```bash
+halpi flash <firmware_file>.bin
+```
+
+### Stänga av automatiska firmwareuppdateringar
+
+Ibland vill man stanna kvar på en viss firmwareversion och stänga av de automatiska uppdateringarna. Det gör du genom att redigera HALPI2:s konfigurationsfil:
+
+```bash
+sudo nano /etc/halpid/firmware.conf
+```
+
+Leta upp inställningen `AUTO_FLASH_ON_INSTALL` och sätt den till `no`:
+
+```bash
+AUTO_FLASH_ON_INSTALL=no
+```
+
+Spara filen och avsluta redigeraren. HALPI2 flashar då inte längre ny firmware automatiskt vid vanliga uppdateringar, och du bestämmer själv när det ska ske. Firmwareuppdateringar kan fortfarande installeras manuellt med `halpi flash`.
+
+
+## Kommandoradsverktyget HALPI
+
+HALPI2:s programvarugränssnitt består av tjänsten `halpid` och kommandoradsverktyget `halpi`. Tillsammans ger de övervakning, konfiguration och styrning av systemet.
+
+### HALPI-daemon (`halpid`)
+
+HALPI-daemonen körs som en systemtjänst och sköter kommunikationen mellan operativsystemet och HALPI2:s styrkrets. Den möjliggör co-op-läget med full övervakning och strömhantering.
+
+#### Hantering av tjänsten
+
+Daemonen styrs via systemd:
+
+```bash
+# Check daemon status
+systemctl status halpid
+
+# Start the daemon
+sudo systemctl start halpid
+
+# Stop the daemon
+sudo systemctl stop halpid
+
+# Enable auto-start at boot
+sudo systemctl enable halpid
+
+# Disable auto-start
+sudo systemctl disable halpid
+
+# View daemon logs
+journalctl -u halpid -f
+```
+
+#### Konfiguration
+
+Daemonens konfiguration ligger i `/etc/halpid/halpid.conf`. För att redigera den:
+
+```bash
+sudo nano /etc/halpid/halpid.conf
+```
+
+Ändringar kräver att daemonen startas om:
+
+```bash
+sudo systemctl restart halpid
+```
+
+### Kommandoradsverktyget HALPI (`halpi`)
+
+Kommandot `halpi` ger direkt tillgång till styrkretsens funktioner och systemets tillstånd. Det kommunicerar med daemonen för att köra kommandon och hämta uppgifter om HALPI2:s driftstillstånd, konfiguration och hårdvaruvärden.
+
+#### Systemtillstånd och övervakning
+
+Kommandoradsverktygets huvuduppgift är att ge en heltäckande bild av systemets tillstånd: hårdvaruvärden, driftstillstånd och övervakningsdata i realtid.
+
+Visa systemets tillstånd:
+
+```bash
+# Display comprehensive system status
+halpi status
+```
+
+Kommandot ger en fullständig översikt över HALPI2:s aktuella driftstillstånd, inklusive spänningar, strömförbrukning, temperaturer och styrkretsens status:
+
+```
+$ halpi status
+ hardware_version               N/A
+ firmware_version             3.1.0
+ state              OperationalCoOp
+ 5v_output_enabled             True
+ watchdog_enabled              True
+ watchdog_timeout              10.0  s
+ watchdog_elapsed               0.0  s
+ V_in                          12.2  V
+ I_in                          0.38  A
+ V_supercap                   10.27  V
+ T_mcu                         43.3  °C
+ T_pcb                         35.2  °C
+```
+
+Om du bara vill följa ett enskilt värde hämtar du det så här:
+
+```bash
+# Show controller firmware version
+halpi get firmware_version
+```
+
+För skript är REST-gränssnittet lämpligare; det beskrivs i avsnittet [Åtkomst via REST-API:et](#atkomst-via-rest-apiet).
+
+#### Hantering av konfigurationen
+
+Med kommandoradsverktyget HALPI kan du se de aktuella inställningarna och ändra driftsparametrarna.
+
+Visa nuvarande konfiguration:
+
+```bash
+# Show current configuration
+halpi config
+```
+
+Det visar alla konfigurerbara parametrar och deras aktuella värden:
+
+```
+$ halpi config
+ Key                       Value
+ watchdog_timeout           10.0
+ power_on_threshold          8.0
+ solo_power_off_threshold    5.5
+ led_brightness               40
+ auto_restart               True
+ solo_depleting_timeout      5.0
+```
+
+#### Styrning av lysdioderna
+
+En av de inställningar som ändras oftast är lysdiodernas ljusstyrka, som går att anpassa till miljön och egna önskemål.
+
+Exempel på kommandon för ljusstyrkan:
+
+```bash
+# Get current LED brightness (0-255)
+halpi config get led_brightness
+
+# Set LED brightness to low level for night operation
+halpi config set led_brightness 40
+
+# Set moderate brightness
+halpi config set led_brightness 64
+
+# Turn LEDs off completely
+halpi config set led_brightness 0
+
+# Maximum brightness for daylight operation
+halpi config set led_brightness 255
+```
+
+Ljusstyrkan tar värden från 0 (helt släckt) till 255 (maximal ljusstyrka), vilket ger en fin justering av lysdioderna på frontpanelen.
+
+#### Strömhantering
+
+Kommandoradsverktyget HALPI ger de strömhanteringsfunktioner som behövs för säker drift.
+
+Exempel:
+
+```bash
+# Initiate graceful shutdown
+halpi shutdown
+
+# Enter standby mode (when available)
+halpi standby
+```
+
+Avstängningskommandot ser till att systemet stängs av säkert: operativsystemet hinner stänga program och avmontera filsystem innan styrkretsen bryter spänningen.
+
+#### Åtkomst via REST-API:et
+
+För erfarna användare och egna program erbjuder HALPI-daemonen även ett REST-gränssnitt via en Unix-socket. Det ger snabbare programmatisk åtkomst till systemets data:
+
+Några användningsexempel:
+
+```bash
+# Get all system values
+curl --unix-socket /var/run/halpid.sock http://localhost/values
+
+# Get all configuration parameters
+curl --unix-socket /var/run/halpid.sock http://localhost/config
+
+# Get individual parameter values
+curl --unix-socket /var/run/halpid.sock http://localhost/values/V_supercap
+```
+
+REST-gränssnittet är särskilt användbart för övervakningsprogram, system för datalagring eller annan programvara som behöver läsa HALPI2:s tillstånd i realtid.
+
+Den fullständiga beskrivningen av REST-API:et finns i kapitlet [Programvaruutveckling: HALPI2-daemon](../software-development/daemon.md).

--- a/docs/sv/user-guide/troubleshooting.md
+++ b/docs/sv/user-guide/troubleshooting.md
@@ -101,10 +101,10 @@ Om systemet startar om inom 30 sekunder efter en firmwareuppdatering återgår f
     ```
 3. Kontrollera kablagets polaritet — RS-485 använder differentiell signalering på ledarna A och B. Om A och B kastats om fungerar ingen kommunikation.
 
-### Ethernet-länken kommer inte upp
+### Ethernetlänken kommer inte upp
 
-1. Kontrollera ethernet-kabeln och RJ45-kontakten. Prova en annan kabel.
-2. Öppna kapslingen och titta på ethernet-lysdioderna för att se länkens status.
+1. Kontrollera ethernetkabeln och RJ45-kontakten. Prova en annan kabel.
+2. Öppna kapslingen och titta på ethernetlysdioderna för att se länkens status.
 3. Kontrollera länkens status: `ip link show eth0`
 4. Om länken är uppe men ingen IP-adress finns, kontrollera DHCP: `sudo dhclient eth0`
 5. Vid fast IP-konfiguration, kontrollera inställningarna i `/etc/network/interfaces` eller i NetworkManager.

--- a/docs/sv/user-guide/troubleshooting.md
+++ b/docs/sv/user-guide/troubleshooting.md
@@ -1,3 +1,7 @@
+---
+translated_from: 35a84e7f96c0891201c8a8248bf146139684b772
+---
+
 # Felsökning
 
 Den här sidan tar upp vanliga problem du kan stöta på när du använder HALPI2, och hur du löser dem.
@@ -148,8 +152,8 @@ Lysdiodernas mönster gör det snabbt att avgöra systemets tillstånd:
 | Fel | Alla lysdioder blinkar rött | Hårdvarufel — kontakta tillverkaren |
 
 !!! quote "Relaterad information"
-    - **LED-mönster:** se [Status-LED:ar](./operation.md#status-led-indicators)
-    - **Strömhantering:** se [Strömhantering och avstängning](./operation.md#power-management-and-shutdown-procedures)
+    - **LED-mönster:** se [Status-LED:ar](./operation.md#status-ledar)
+    - **Strömhantering:** se [Strömhantering och avstängning](./operation.md#stromhantering-och-avstangning)
     - **Hantering av daemonen:** se [Programvaruguiden](./software.md#halpi-daemon-halpid)
     - **Detaljer om CAN-gränssnittet:** se [Gränssnitt och anslutningar](./interfaces.md#can-fd-nmea-2000)
     - **Detaljer om RS-485-gränssnittet:** se [Gränssnitt och anslutningar](./interfaces.md#rs-485-nmea-0183)

--- a/docs/sv/user-guide/troubleshooting.md
+++ b/docs/sv/user-guide/troubleshooting.md
@@ -1,0 +1,155 @@
+# Felsökning
+
+Den här sidan tar upp vanliga problem du kan stöta på när du använder HALPI2, och hur du löser dem.
+
+## Problem med ström och start
+
+### Systemet startar inte
+
+**Symtom:** ingen aktivitet i lysdioderna, inga livstecken efter att strömmen anslutits.
+
+1. Kontrollera med en multimeter vid E7T-kontakten att inspänningen ligger inom området (11–32 V DC).
+2. Kontrollera strömkabelns anslutningar — se till att E7T-kontakten är helt intryckt.
+3. Om du matar enheten från NMEA 2000-bussen, kontrollera att strömbegränsningen är inställd på 0,9 A och att nätverket kan leverera tillräckligt med ström.
+4. Öppna kapslingen och leta efter synliga skador eller lösa interna anslutningar.
+
+### Regnbågsfärgade lysdioder
+
+**Symtom:** lysdioderna löper genom ett regnbågsmönster och når aldrig ett stabilt läge.
+
+Regnbågsmönstret betyder att styrkretsen har fått spänning men att CM5 inte hittas. Det kan bero på att:
+
+- Compute Module inte är monterad eller inte sitter ordentligt.
+- Compute Module är trasig.
+- En ansluten enhet matar in läckspänningar som hindrar CM5 från att starta — prova att koppla bort HDMI-kabeln.
+
+1. Koppla bort alla HDMI-skärmar och starta om för att utesluta läckspänningar.
+2. Om problemet kvarstår, öppna kapslingen och kontrollera att CM5-modulen sitter helt i sin kontakt — det kräver att bärkortet demonteras.
+
+### Lysdioderna förblir gula
+
+**Symtom:** lysdioderna går från rött (laddning) till gult (spänning på) men blir aldrig gröna.
+
+Gult betyder att styrkretsen har slagit på CM5 och väntar på svar från daemonen. Om lysdioderna förblir gula startar antingen inte operativsystemet, eller så är HALPI-daemonen inte installerad.
+
+1. Kontrollera att startlägesomkopplaren står i läget ”Normal” — den gula indikeringslysdioden bredvid tänds när läget är ”Abnormal” (USB-start).
+2. Anslut en skärm via HDMI för att se startfel eller inloggningsprompten.
+3. Kontrollera att NVMe SSD-enheten sitter ordentligt i sin M.2-plats.
+4. Om operativsystemet startar som det ska, kontrollera att daemonen är installerad: `systemctl status halpid`
+5. Om daemonen är installerad men inte körs, titta i dess loggar: `journalctl -u halpid -e`
+
+### Systemet stängs av oväntat
+
+**Symtom:** systemet stänger av sig utan åtgärd, trots att den externa strömförsörjningen är ansluten.
+
+1. Kontrollera inspänningens stabilitet — korta dippar under tröskeln utlöser avbrottstimern. Följ `V_in` i realtid med `halpi status`.
+2. Undersök strömkabeln efter lösa anslutningar eller skadade ledare som kan ge glappkontakt.
+3. Om du matar enheten från NMEA 2000-bussen, kontrollera att nätverkets spänning håller sig stabil under belastning. Andra strömtörstiga enheter på nätverket kan orsaka spänningsfall.
+
+## Firmwareuppdatering misslyckades eller återställdes
+
+Om systemet startar om inom 30 sekunder efter en firmwareuppdatering återgår firmwaren automatiskt till föregående version som säkerhetsåtgärd.
+
+1. Kontrollera nuvarande firmwareversion: `halpi get firmware_version`
+2. Gör om uppdateringen: `sudo apt update && sudo apt install --reinstall halpi2-firmware`
+3. När uppdateringen är installerad, stäng av kontrollerat: `sudo shutdown -h now`
+4. Vänta tills systemet är helt avstängt innan du kopplar in det igen — låt minst 30 sekunder gå före nästa start så att återställningsmekanismen inte löser ut.
+
+## Problem med nätverk och gränssnitt
+
+### Inga NMEA 2000-data
+
+**Symtom:** `candump can0` visar ingenting, eller Signal K tar inte emot data.
+
+1. Kontrollera CAN-gränssnittets status:
+    ```bash
+    ip link show can0
+    ```
+    Gränssnittet ska visa `UP`. Om det visar `DOWN`, aktivera det:
+    ```bash
+    sudo ip link set can0 up type can bitrate 250000
+    ```
+
+2. Titta på RX-lysdioden på bärkortet — den ska blinka när det finns trafik på nätverket. Om RX-lysdioden är släckt:
+    - kontrollera Micro-C-kabelns anslutning och T-kopplingens placering;
+    - se till att NMEA 2000-nätverket har spänning och att andra enheter sänder;
+    - kontrollera att bygeln för 120 Ω-terminering **inte** är isatt i NMEA 2000-nätverk.
+
+3. Om RX-lysdioden blinkar men `candump` inte visar något ligger felet i programvaran. Kontrollera CAN-gränssnittets konfiguration:
+    ```bash
+    ip -details link show can0
+    ```
+
+4. Leta efter fel på CAN-bussen:
+    ```bash
+    ip -statistics link show can0
+    ```
+    Höga felräknare tyder på kabelproblem, fel överföringshastighet eller konkurrens på bussen.
+
+### Inga NMEA 0183-data på RS-485
+
+**Symtom:** inga data på `/dev/ttyAMA4`, eller den anslutna enheten svarar inte.
+
+1. Öppna kapslingen och titta på RS-485-gränssnittets lysdioder — RX-lysdioden ska blinka när data tas emot.
+2. Kontrollera att serieporten finns och är åtkomlig:
+    ```bash
+    ls -l /dev/ttyAMA4
+    ```
+3. Kontrollera kablagets polaritet — RS-485 använder differentiell signalering på ledarna A och B. Om A och B kastats om fungerar ingen kommunikation.
+
+### Ethernet-länken kommer inte upp
+
+1. Kontrollera ethernet-kabeln och RJ45-kontakten. Prova en annan kabel.
+2. Öppna kapslingen och titta på ethernet-lysdioderna för att se länkens status.
+3. Kontrollera länkens status: `ip link show eth0`
+4. Om länken är uppe men ingen IP-adress finns, kontrollera DHCP: `sudo dhclient eth0`
+5. Vid fast IP-konfiguration, kontrollera inställningarna i `/etc/network/interfaces` eller i NetworkManager.
+
+## Problem med operativsystemet
+
+### Går inte att ansluta med SSH
+
+1. Kontrollera att SSH är aktiverat: `sudo systemctl status ssh`
+2. Kontrollera nätverksanslutningen — svarar enheten på ping?
+3. SSH är aktiverat som standard i HaLOS-avbilder utan skärm och i OpenPlotter. I HaLOS Desktop-varianterna och i Raspberry Pi OS aktiverar du SSH med `raspi-config`.
+
+### Systemet är långsamt eller hänger sig
+
+1. Kontrollera processorns temperatur — hög omgivningstemperatur kan orsaka termisk nedvarvning. Använd:
+    ```bash
+    vcgencmd measure_temp
+    ```
+    Temperaturer över 80 °C tyder på ett värmeproblem. Sänk omgivningstemperaturen eller förbättra luftcirkulationen runt kapslingen.
+
+2. Kontrollera minnesanvändningen: `free -h`
+3. Kontrollera diskutrymmet: `df -h` — en full NVMe SSD ger kraftiga prestandaproblem.
+4. Leta efter processer som skenat: `top` eller `htop`
+
+### Klockan går fel efter ett strömavbrott
+
+HALPI2 har en realtidsklocka (RTC) med backupbatteri som håller tiden under strömavbrott. Om klockan nollställs:
+
+1. Kontrollera RTC-batteriet — det kan behöva bytas om enheten har stått utan spänning länge.
+2. Kontrollera NTP-synkroniseringen när nätverket är tillgängligt: `timedatectl status`
+3. Ställ tiden manuellt vid behov: `sudo timedatectl set-time "2025-01-15 14:30:00"`
+
+## Diagnostik med lysdioderna
+
+Lysdiodernas mönster gör det snabbt att avgöra systemets tillstånd:
+
+| Symtom | LED-mönster | Trolig orsak |
+|:-------|:------------|:-------------|
+| Systemet startar inte | Inga lysdioder | Ingen inspänning eller hårdvarufel |
+| Fastnar under start | Röd successiv fyllning | Superkondensatorerna laddas fortfarande — vänta |
+| Fastnar under start | Regnbågsmönster | CM5 hittas inte — kontrollera modulens montering och koppla bort skärmar |
+| Förblir gul | Fast gul | Operativsystemet startar inte, eller daemonen är inte installerad |
+| Oväntad avstängning | Rullande grönt/gult | Spänningsbortfall upptäckt — kontrollera inspänningen |
+| Överspänning | LED 1 blinkar rött | Inspänningen för hög (över 32 V) |
+| Fel | Alla lysdioder blinkar rött | Hårdvarufel — kontakta tillverkaren |
+
+!!! quote "Relaterad information"
+    - **LED-mönster:** se [Status-LED:ar](./operation.md#status-led-indicators)
+    - **Strömhantering:** se [Strömhantering och avstängning](./operation.md#power-management-and-shutdown-procedures)
+    - **Hantering av daemonen:** se [Programvaruguiden](./software.md#halpi-daemon-halpid)
+    - **Detaljer om CAN-gränssnittet:** se [Gränssnitt och anslutningar](./interfaces.md#can-fd-nmea-2000)
+    - **Detaljer om RS-485-gränssnittet:** se [Gränssnitt och anslutningar](./interfaces.md#rs-485-nmea-0183)

--- a/docs/sv/user-guide/use-cases.md
+++ b/docs/sv/user-guide/use-cases.md
@@ -1,0 +1,7 @@
+# Vanliga användningsfall
+
+- Uppsättning av navigationssystem
+- Datalagring och övervakning
+- Konfiguration av Signal K-server
+- Integration med befintliga båtsystem
+- Tillämpningar inom industriautomation

--- a/docs/sv/user-guide/use-cases.md
+++ b/docs/sv/user-guide/use-cases.md
@@ -1,3 +1,7 @@
+---
+translated_from: 347076aa60c0c593af503f8af30bc480108964b8
+---
+
 # Vanliga användningsfall
 
 - Uppsättning av navigationssystem

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -150,6 +150,42 @@ plugins:
             Errata: Bekannte Fehler
             Resources: Ressourcen
             FAQ: FAQ
+        - locale: sv
+          name: Svenska
+          build: true
+          site_name: HALPI2-användarhandbok
+          site_description: Användarhandbok för HALPI2, ett Raspberry Pi CM5-bärkort för marina och industriella tillämpningar
+          admonition_translations:
+            note: Obs
+            warning: Varning
+            tip: Tips
+            info: Information
+            danger: Fara
+            example: Exempel
+          nav_translations:
+            Introduction: Introduktion
+            Getting Started: Kom igång
+            User Guide: Användarhandbok
+            System Operation: Systemdrift
+            Hardware Guide: Hårdvaruguide
+            Interfaces and Connectivity: Gränssnitt och anslutningar
+            Software Guide: Programvaruguide
+            Troubleshooting: Felsökning
+            Technical Reference: Teknisk referens
+            Hardware Reference: Hårdvarureferens
+            Power Supply Deep Dive: Strömförsörjningen i detalj
+            Carrier Board Controller: Bärkortets styrkrets
+            Software Development: Programvaruutveckling
+            HALPI2 Daemon: HALPI2-daemon
+            System Integration: Systemintegration
+            Advanced Configuration: Avancerad konfiguration
+            Other Debian Distributions: Andra Debian-distributioner
+            Appendices: Bilagor
+            Design Files and Schematics: Konstruktionsfiler och kopplingsscheman
+            Compliance and Certifications: Överensstämmelse och certifieringar
+            Errata: Kända fel
+            Resources: Resurser
+            FAQ: Vanliga frågor
 
 markdown_extensions:
   - admonition

--- a/scripts/check_glossary.py
+++ b/scripts/check_glossary.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+"""Check that a translation actually uses the terms its glossary prescribes.
+
+A glossary read before translating looks followed afterwards, because rereading
+one's own text confirms whatever it already says. Every language branch so far
+reached review with a term the glossary defines and the pages ignore — a second
+name for the same connector, one page apart, which no reader can reconcile.
+
+The check is indirect but cheap: if a glossary term appears in the English
+source and its prescribed translation appears nowhere in the target language,
+some other word is doing that job. Run it before opening a pull request.
+
+It finds a term that is never used, not a term that has acquired a rival. German
+says both `Spannungsausfall` and `Stromausfall` for *blackout* and passes here,
+because the prescribed word does appear. Catching that needs the rival named,
+which is what the glossary cannot know in advance.
+
+Exit status is 1 if any prescribed term is unused.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+GLOSSARIES = {
+    "fi": "finnish-glossary.md",
+    "fr": "french-glossary.md",
+    "de": "german-glossary.md",
+    "sv": "swedish-glossary.md",
+}
+
+ROW = re.compile(r"^\| *`?([^|`]+?)`? *\| *`?([^|`]+?)`? *\|")
+SHORTEST_TERM = 5
+# An English term used once may be phrased around; twice is a pattern.
+MIN_ENGLISH_USES = 2
+
+
+def read_pages(directory: Path) -> str:
+    """Concatenate a language's markdown with code and frontmatter removed."""
+    out = []
+    for page in sorted(directory.rglob("*.md")):
+        raw = page.read_text(encoding="utf-8")
+        text = re.sub(r"^---\n.*?\n---\n", "", raw, flags=re.S)
+        text = re.sub(r"```.*?```", " ", text, flags=re.S)
+        out.append(re.sub(r"`[^`\n]*`", " ", text))
+    return "\n".join(out).lower()
+
+
+def terms(glossary: Path) -> list[tuple[str, str]]:
+    """Extract (english, translation) pairs from the glossary tables."""
+    pairs = []
+    for line in glossary.read_text(encoding="utf-8").splitlines():
+        row = ROW.match(line)
+        if not row:
+            continue
+        english, translated = row.group(1).strip(), row.group(2).strip()
+        if english.lower().startswith("english") or set(english) <= set(":- "):
+            continue
+        pairs.append((english, translated))
+    return pairs
+
+
+def alternatives(term: str) -> list[str]:
+    """Split a glossary cell into the forms that would each satisfy it."""
+    term = re.sub(r"\s*\([^)]*\)", "", term).lower()
+    return [part.strip() for part in term.split("/") if part.strip()]
+
+
+def inflectable(term: str) -> re.Pattern[str]:
+    """Match a term in whatever form a sentence needs.
+
+    Every word may take an ending, not just the last one: Finnish inflects both
+    halves of `vapaa tila` and French pluralises both halves of `bouchon
+    obturateur`, so anchoring on the phrase as written finds neither. A verb
+    phrase also takes its object in the middle — `aseta CM5 uudelleen
+    paikalleen` — so a couple of words are allowed to intervene.
+    """
+    words = [re.escape(w[: max(4, len(w) - 3)]) + r"\w*" for w in term.split()]
+    return re.compile(r"(?:\W+\w+){0,2}\W+".join(words))
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "language", choices=sorted(GLOSSARIES), help="target language code"
+    )
+    parser.add_argument("--docs", default="docs", help="documentation root")
+    parser.add_argument(
+        "--glossaries",
+        default="solutions/translation",
+        help="directory holding the glossaries",
+    )
+    args = parser.parse_args()
+
+    english = read_pages(Path(args.docs) / "en")
+    translated = read_pages(Path(args.docs) / args.language)
+    glossary = Path(args.glossaries) / GLOSSARIES[args.language]
+
+    checked, unused = 0, []
+    for source, target in terms(glossary):
+        wanted = [w for w in alternatives(source) if len(w) >= SHORTEST_TERM]
+        have = [h for h in alternatives(target) if len(h) >= SHORTEST_TERM]
+        if not wanted or not have:
+            continue
+        uses = sum(english.count(w) for w in wanted)
+        if uses < MIN_ENGLISH_USES:
+            continue
+        checked += 1
+        if not any(inflectable(h).search(translated) for h in have):
+            unused.append((source, target, uses))
+
+    print(f"Checked {checked} glossary terms against docs/{args.language}.")
+    if unused:
+        print(f"\n{len(unused)} prescribed but unused — something else took over:\n")
+        for source, target, uses in unused:
+            print(f"  {source}  ->  {target}   (English {uses}×, translation never)")
+        return 1
+    print("Every prescribed term is in use.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/solutions/translation/swedish-glossary.md
+++ b/solutions/translation/swedish-glossary.md
@@ -1,0 +1,239 @@
+---
+title: Swedish translation glossary and style rules
+date: 2026-08-04
+category: translation
+module: documentation
+problem_type: reference
+component: documentation
+severity: medium
+applies_when:
+  - Translating any page from docs/en/ into Swedish under docs/sv/
+  - Reviewing a Swedish translation for consistency
+  - Adding a new term that has no established Swedish equivalent
+tags:
+  - translation
+  - i18n
+  - swedish
+  - terminology
+  - mkdocs-static-i18n
+---
+
+# Swedish translation glossary and style rules
+
+## Context
+
+The HALPI2 documentation is written in English under `docs/en/` and translated
+into Swedish under `docs/sv/`, using the `mkdocs-static-i18n` folder structure.
+Each language directory mirrors the same tree, so a translation keeps its
+source's path and filename. Only markdown lives under `docs/sv/`; images and
+other assets stay with the English source and are shared.
+
+`finnish-glossary.md`, `french-glossary.md` and `german-glossary.md` are the
+siblings of this file. The general approach is the same in all four.
+
+## Four rules where the siblings are wrong for Swedish
+
+Read this section before anything else. Every one of these is stated the
+opposite way in at least one sibling glossary, and carrying the wrong habit
+across has already cost two correction rounds on earlier branches.
+
+1. **Address the reader as `du`, not formally.** Swedish technical and consumer
+   documentation uses `du`. French uses *vouvoiement* and German uses *Sie* —
+   both wrong here. `Anslut strömkabeln.` / `Kontrollera polariteten med
+   multimetern innan du slår på spänningen.`
+
+2. **Quotation marks are `”…”`** — the *same* character (U+201D) on both sides.
+   Not German's `„…“`, not French's `« … »`, not straight `"…"`.
+
+3. **No space before `; : ! ?`** — as in German, and unlike French, whose rule is
+   the exact opposite and demands a no-break space.
+
+4. **Compounding with a proper name takes one hyphen at the junction, not
+   throughout.** Swedish writes `NMEA 2000-nätverk`, `Signal K-server`,
+   `Raspberry Pi-antenn`. German writes `NMEA-2000-Netzwerk` — hyphens all the
+   way through. Copying the German pattern into Swedish is wrong, and it is the
+   single most likely way this glossary gets violated.
+
+## Names that are never translated
+
+Identical to the sibling glossaries: product names, protocol names, hardware
+standards and software UI strings stay in English — HALPI2, HaLOS, Signal K,
+OpenPlotter, Raspberry Pi OS, Cockpit, Homarr, Authelia, Grafana, Hat Labs,
+Compute Module 5 (CM5), NMEA 2000, NMEA 0183, CAN FD, RS-485, NVMe SSD, GPIO,
+HDMI, MIPI, USB, RP-SMA, E7T, PG7, SP13, IP65, DHCP, SSH, SSL, ABYC, Cat5e, AWG,
+plus every UI path, command, hostname and file path.
+
+Code fences, command output, URLs and image filenames are never touched.
+
+## Units and numbers
+
+Same handling as the other languages — the English source writes `12V` and
+`0.9A`, and both are wrong in Swedish.
+
+| English source | Swedish |
+|:---------------|:--------|
+| `12V`, `0.9A` | `12 V`, `0,9 A` |
+| `5.5 x 2.1 mm` | `5,5 × 2,1 mm` |
+| `-20°C to +60°C` | `−20 °C … +60 °C` |
+| `120Ω` | `120 Ω` |
+| `3-5A` | `3–5 A` (en dash for ranges) |
+
+## Links, images, admonitions, navigation
+
+Same as the sibling glossaries: paths are copied from the English source
+unchanged and never carry a language segment; image captions and alt texts are
+translated but filenames are not; screenshots stay English because the reader's
+own screen is English; standard admonition titles are translated centrally in
+`mkdocs.yml`, custom ones in the page.
+
+## Glossary
+
+### Enclosure, mounting, and installation
+
+| English | Swedish | Note |
+|:--------|:--------|:-----|
+| carrier board | bärkort | The accurate term, as in French and German |
+| enclosure | kapsling | |
+| heat sink | kylfläns | |
+| waterproof | vattentät | |
+| wall-mount | väggmontage | |
+| mounting surface | monteringsyta | |
+| pilot hole | förborrat hål | |
+| mounting template | borrmall | |
+| bilge water | slagvatten | |
+| bulkhead | skott | |
+| cable gland | kabelgenomföring | |
+| cable routing | kabeldragning | |
+| service loop | servicelänga | Slack left at both cable ends |
+| cable tie | buntband | |
+| blind plug | blindplugg | |
+| breather plug | tryckutjämningsplugg | |
+
+**A note on `bärkort`.** Swedish takes the accurate term, like French
+(`carte porteuse`) and German (`Trägerplatine`), and unlike Finnish (`emolevy`,
+literally *motherboard*, chosen there for reader familiarity). The divergence
+between the four is deliberate, decided per language and per audience. Do not
+harmonise them.
+
+`bärkort` carries the CM5/board relationship on its own, so passages about
+reseating the CM5 or troubleshooting a board that will not boot need no extra
+explanation. Only the Finnish glossary needs that warning.
+
+### Electrical
+
+| English | Swedish | Note |
+|:--------|:--------|:-----|
+| power supply | strömförsörjning | The unit itself: *nätaggregat* |
+| input voltage range | inspänningsområde | |
+| polarity | polaritet | |
+| fuse | säkring | |
+| inline fuse | linjesäkring | |
+| circuit breaker | automatsäkring | |
+| current limiting | strömbegränsning | |
+| overcurrent | överström | |
+| voltage drop | spänningsfall | |
+| grounding | jordning | |
+| short circuit | kortslutning | |
+| wire gauge | ledararea | Swedish uses mm², not AWG |
+| marine-grade wire | sjövattenbeständig ledare | |
+| wire strippers | avisoleringstång | |
+| crimping | krimpning | |
+| crimper | krimptång | |
+| heat-shrink tubing | krympslang | |
+| heat gun | varmluftspistol | |
+| multimeter | multimeter | |
+| terminal block | kopplingsplint | |
+| strain relief | dragavlastning | |
+| super-capacitor | superkondensator | |
+| real-time clock | realtidsklocka | |
+| backup battery | backupbatteri | |
+
+### Connectors and interfaces
+
+| English | Swedish | Note |
+|:--------|:--------|:-----|
+| connector | kontakt / anslutning | *anslutning* for a board-mounted socket |
+| barrel connector | hålkontakt | |
+| header | stiftlist | `40-polig GPIO-stiftlist` |
+| pin | stift | |
+| backbone | backbone | Established in Swedish NMEA 2000 usage |
+| drop cable | stickledning | |
+| T-connector | T-koppling | |
+| termination (120 Ω) | termineringsmotstånd | |
+| front panel | frontpanel | |
+| jumper | bygel | |
+| male / female | hane / hona | |
+
+### System behaviour and status
+
+| English | Swedish | Note |
+|:--------|:--------|:-----|
+| boat computer | båtdator | |
+| to boot | starta | |
+| first boot | första start | |
+| shutdown | avstängning | |
+| graceful shutdown | kontrollerad avstängning | |
+| power loss | spänningsbortfall | |
+| blackout | strömavbrott | |
+| power management | strömhantering | |
+| status LED | status-LED | |
+| monitoring | övervakning | |
+| passive cooling | passiv kylning | |
+| filesystem | filsystem | |
+| to unmount | avmontera | |
+| watchdog | watchdog | |
+| standby | vänteläge | |
+
+### Software and networking
+
+| English | Swedish | Note |
+|:--------|:--------|:-----|
+| firmware | firmware | Not *fast programvara* — matches the sibling decision to keep the trade term |
+| daemon | daemon | |
+| to flash | flasha | |
+| operating system image | systemavbild | |
+| headless | utan skärm | First mention: `utan skärm (headless)` |
+| container app | containerapp | |
+| container image | containeravbild | |
+| dashboard | instrumentpanel | Homarr's *dashboard* view |
+| WiFi Access Point | WiFi-accesspunkt | |
+| wired / wireless | trådbunden / trådlös | |
+| credentials | inloggningsuppgifter | |
+| default password | standardlösenord | |
+| single sign-on (SSO) | enkel inloggning (SSO) | |
+| Certificate Authority (CA) | certifikatutfärdare (CA) | |
+| web interface | webbgränssnitt | |
+| browser | webbläsare | |
+
+### Applications and use cases
+
+| English | Swedish | Note |
+|:--------|:--------|:-----|
+| chart plotter | kartplotter | |
+| data logging | datalagring | |
+| vessel | fartyg | |
+| fleet management | flotthantering | |
+| predictive maintenance | förebyggande underhåll | |
+| remote monitoring | fjärrövervakning | |
+| compliance | överensstämmelse | |
+| warranty | garanti | |
+
+## Verification
+
+A translated page is not done until:
+
+1. `uv run mkdocs build --strict` passes.
+2. `uv run python scripts/check_anchors.py site` passes.
+3. `uv run python scripts/translation_status.py` shows the page as current.
+4. Structure matches the source — see `.claude/skills/translate-page/SKILL.md`.
+5. Every term used on the page that appears in this glossary matches it.
+6. **The four rules at the top are tested against the pages, not re-read.** A
+   half-applied typography rule looks followed when you read it. Both the French
+   and German branches shipped one to review because it was read rather than
+   measured.
+
+## Related
+
+- `finnish-glossary.md`, `french-glossary.md`, `german-glossary.md` — siblings
+- `.claude/skills/translate-page/SKILL.md` — the procedure
+- `../best-practices/` — the two markdown traps that survive `--strict`

--- a/solutions/translation/swedish-glossary.md
+++ b/solutions/translation/swedish-glossary.md
@@ -98,7 +98,8 @@ own screen is English; standard admonition titles are translated centrally in
 | waterproof | vattentät | |
 | wall-mount | väggmontage | |
 | mounting surface | monteringsyta | |
-| pilot hole | förborrat hål | |
+| pilot hole (to drill) | förborra (verb) | `Förborra hålen` — never `borra förborrade hål` |
+| pre-drilled hole (already there) | förborrat hål | The holes the enclosure ships with |
 | mounting template | borrmall | |
 | bilge water | slagvatten | |
 | bulkhead | skott | |


### PR DESCRIPTION
Adds Swedish as the fifth locale, completing the set alongside Finnish, French and German.

## Why

The Nordic market is a natural fit for a Finnish marine electronics company, and Swedish is the second official language of Finland. The i18n machinery from #26 and #30 made this a matter of writing the pages — no configuration work beyond a locale block.

## What is here

All 21 pages under `docs/sv/`, a `swedish-glossary.md` in `solutions/translation/`, and the `sv` locale in `mkdocs.yml` with translated admonitions and navigation.

The glossary opens with four rules where the sibling languages are actively wrong for Swedish, because the temptation to copy a pattern that worked in French or German is real:

1. Address the reader as `du`. French uses *vouvoiement*, German uses *Sie*; Swedish does neither.
2. Quotation marks are `”…”` — the same character (U+201D) on both sides, unlike German's `„…“`.
3. No space before `; : ! ?` — the exact opposite of the French rule that this repo already enforces.
4. Compounding with a proper name takes **one** hyphen, at the junction: `NMEA 2000-nätverk`, `Signal K-server`, `Raspberry Pi-antenn`. Not German's hyphens throughout.

## Verification

Both earlier translation branches reached review with a half-applied typography rule, because reading one's own work makes it look like the rule was followed. So the four rules above were measured against the pages rather than re-read:

| Check | Result |
|:------|:-------|
| `mkdocs build --strict` | clean |
| `check_anchors.py` | 4875 anchors across 107 pages, all resolve |
| Formal address (`Ni`/`Er`) | 0 occurrences |
| Quotation marks | 54 × `”`, 0 × `“`, 0 ASCII quotes; even count on every page |
| Space before `; : ! ?` | 0 occurrences |
| Over-hyphenated proper nouns | 0 occurrences |

The anchor pass fixed 18 cross-page links. They break only once the *target* page is translated, so they were invisible until this branch — the same delayed fault the other language branches hit.

Thirteen pages contain no second-person address at all. That is not an omission: their English counterparts contain no "you" either. They are reference pages that describe the hardware rather than instruct the reader.

## What this needs from a reader

**Nobody who reads Swedish has read this.** The terminology choices are mine, derived from Swedish marine usage rather than confirmed by a native speaker — `bärkort` (carrier board), `stickledning` (drop cable), `kapsling` (enclosure), `slagvatten` (bilge water), `termineringsmotstånd` (terminator). Corrections belong in `solutions/translation/swedish-glossary.md` so the next translator inherits them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
