### PR TITLE
fix(i18n): stop reading a table's alignment row as prose

### DIFF
--- a/scripts/check_typography.py
+++ b/scripts/check_typography.py
@@ -67,6 +67,9 @@ def prose(text: str) -> str:
     text = re.sub(r"`[^`\n]*`", "X", text)
     text = re.sub(r'^!!! \w+ ".*"$', "", text, flags=re.M)  # admonition syntax quotes
     text = re.sub(r"\]\([^)]*\)", "]", text)  # link targets
+    # A table's delimiter row carries the column alignment as colons — | ---: |
+    # — which reads as a space before a colon and is not prose at all.
+    text = re.sub(r"^[|\s:-]+$", "", text, flags=re.M)
     # Repository names and filenames are identifiers that happen to contain
     # hyphens — HALPI2-hardware, HALPI2-schematic_v0.6.1.pdf — and reading them
     # as compounds of the target language invents defects that are not there.


### PR DESCRIPTION
`check_typography.py` read a markdown table's alignment row as prose.

A right-aligned column writes its delimiter as `| ---: |`, and the rule that forbids a space before `; : ! ?` matched the space in front of that colon. The row is table syntax, not a sentence.

## Why it never showed here

No page in this repository has a right-aligned column, so the checker has been reporting clean by luck rather than by being correct. The fault surfaced in hatlabs/halmet#18, where the GPIO reference table right-aligns its first column, and the same script — copied from here — reported two false positives on a correct page.

## Reproduced before fixing

Adding such a table to `docs/fi/` produces exactly one false positive:

```
fi: 22 pages, 0 quotations (”…”), quote faults 0, spacing 1, hyphen chains 0 — 1 PROBLEMS
    docs/fi/_probe.md: space before ':': ...
```

After the fix the same file reports clean, and all nine translated languages are unchanged in both directions — they passed before and they pass now, which is the point: this must not alter any existing verdict.

## Note

This is the fifth false positive this checker has produced during its short life, and every one of them was caught the same way — by running it against pages already reviewed and fixed. If it reports a defect there, the defect is in the checker. That is worth keeping as the habit rather than trusting a clean first run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
