### PR TITLE
fix(i18n): stop the glossary checker reporting a false green

### DIFF
--- a/scripts/check_glossary.py
+++ b/scripts/check_glossary.py
@@ -97,9 +97,23 @@ def inflectable(term: str) -> re.Pattern[str]:
     obturateur`, so anchoring on the phrase as written finds neither. A verb
     phrase also takes its object in the middle — `aseta CM5 uudelleen
     paikalleen` — so a couple of words are allowed to intervene.
+
+    The match must start at a word boundary, or a compounding language reports
+    a term as used when only a longer word containing it is present: Finnish
+    `virtalähde` (power supply) is a substring of `vakiovirtalähde` (constant
+    current source), two different components. Without the boundary this check
+    returns a false green, which is worse than a false alarm — a checker that
+    passes when it should not is no checker at all.
+
+    The boundary only applies when the term starts with a word character. A row
+    like `−32 V and +32 V` opens with a minus sign, and `\\b` before a non-word
+    character asserts the opposite of what is meant — it would demand a letter
+    immediately before the minus and match nothing.
     """
     words = [re.escape(w[: max(3, len(w) - 3)]) + r"\w*" for w in fold(term).split()]
-    return re.compile(r"(?:\W+\w+){0,2}\W+".join(words))
+    body = r"(?:\W+\w+){0,2}\W+".join(words)
+    boundary = r"\b" if re.match(r"\w", fold(term)) else ""
+    return re.compile(boundary + body)
 
 
 def main() -> int:


### PR DESCRIPTION
`check_glossary.py` was reporting a **false green**: it matched a prescribed term inside any longer word containing it, so a term nobody had used counted as used.

Finnish `virtalähde` (power supply) is a substring of `vakiovirtalähde` (constant current source). Those are two unrelated components, but the unanchored pattern `virtala\w*` matches inside the longer word, and the script would print *"Every prescribed term is in use"* while one of them appeared nowhere on its own.

## Why it never showed here

It is latent in this repository — no page happens to hit the case, and **no verdict changes**. It surfaced in hatlabs/halmet#21, whose board has a constant current source described in the same list as its power supply. The two repositories share this script, so a fault found in one is owed to the other.

## Reproduced both ways before fixing

A glossary row whose translation appears only inside a compound:

```
| enclosure | zyxkotelo | probe |
```

with a page that only ever writes `metallizyxkotelo`:

```
before the fix:  Every prescribed term is in use.
after the fix:   enclosure  ->  zyxkotelo   (English 77×, translation never)
```

The probe was removed. All nine translated languages are unchanged in both directions — they passed before and they pass now, which is the point: this must not alter any existing verdict.

## The boundary is conditional

`\b` is applied only when the term starts with a word character. A row like `−32 V and +32 V` opens with a minus sign, and a word boundary before a non-word character asserts the opposite of what is meant — it would demand a letter immediately before the minus and match nothing. That was caught by the fix's own first run in the sibling repository, which is the habit worth keeping: run a new check against pages already reviewed and fixed, and if it reports a defect there, the defect is in the check.

## Why this one matters more than the others

Five earlier corrections to these checkers were **false alarms** — the checker cried wolf, someone looked, the fault was in the checker. Those cost a reviewer some time.

This is the opposite. A false green means the check was never doing its job, and both repositories have leaned on it across nineteen language directories.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
