### PR TITLE
fix(theme): show every language in the selector without scrolling

### DIFF
--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -51,3 +51,11 @@
   color: var(--md-default-fg-color--light);
   margin-top: 1.2rem;
 }
+
+/* The theme caps the open language selector at 10rem, which fits five of the
+   ten languages and silently scrolls the rest. 24rem clears thirteen; the
+   viewport term keeps the menu on screen on a short display. */
+.md-select:focus-within .md-select__inner,
+.md-select:hover .md-select__inner {
+  max-height: min(24rem, 75vh);
+}


### PR DESCRIPTION
The language selector shows five of the ten languages. The rest are reachable only by scrolling inside the dropdown, which gives no visual hint that there is anything below.

## Cause

Material caps the open menu:

```css
.md-select:hover .md-select__inner { max-height: 10rem; }
```

At the site's root font size that resolves to 200px, and each entry is 36px tall — five rows. The list needs 360px for ten languages.

## Fix

```css
.md-select:focus-within .md-select__inner,
.md-select:hover .md-select__inner {
  max-height: min(24rem, 75vh);
}
```

24rem resolves to 480px, which clears thirteen entries — enough headroom that adding a language does not immediately reintroduce the problem. The `75vh` term keeps the menu on screen on a short display, where a fixed 24rem would run past the bottom edge.

`:focus-within` is included alongside `:hover` because the theme's own rule covers both, and keyboard users open the menu that way.

## Measured, not estimated

Read from the rendered page rather than assumed:

| | |
|:--|:--|
| Entry height | 36px |
| List needs | 360px for ten languages |
| Old cap resolved to | 200px — five visible |
| New cap resolves to | 480px — all ten visible, room for thirteen |

Verified in the browser on both sites: the menu opens to its full height with no scrollbar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
