### PR TITLE
fix(i18n): follow the Finnish glossary on power supply and power source

### DIFF
--- a/docs/fi/getting-started/getting-started.md
+++ b/docs/fi/getting-started/getting-started.md
@@ -29,7 +29,7 @@ Valinnaiset osat (sisältyvät myyntipakkaukseen):
 
 Lisäksi tarvittavat (eivät sisälly toimitukseen):
 
-- 12 V:n tai 24 V:n virtalähde
+- 12 V:n tai 24 V:n virransyöttö
 - Erillinen tietokone käyttöönottoon ilman näyttöä (headless), jos et käytä kytkettyä näyttöä
 - Verkkokaapeli (valinnainen, langallista yhteyttä varten)
 - Näyttö, jossa on HDMI-tulo (valinnainen)
@@ -161,7 +161,7 @@ Avaa Signal K:n verkkokäyttöliittymä ja tarkkaile `can0`-yhteyden aktiivisuut
 
 ## Laitteen sammuttaminen
 
-HALPI2 on suunniteltu sammumaan automaattisesti, kun virransyöttö katkaistaan. Kun haluat sammuttaa laitteen, katkaise virta joko sähkötaulun kytkimestä tai irrottamalla virtaliitin. Järjestelmä käynnistää sammutuksen automaattisesti, jolloin kaikki sovellukset sulkeutuvat hallitusti ja tiedostojärjestelmä irrotetaan turvallisesti.
+HALPI2 on suunniteltu sammumaan automaattisesti, kun virtalähde irrotetaan. Kun haluat sammuttaa laitteen, katkaise virta joko sähkötaulun kytkimestä tai irrottamalla virtaliitin. Järjestelmä käynnistää sammutuksen automaattisesti, jolloin kaikki sovellukset sulkeutuvat hallitusti ja tiedostojärjestelmä irrotetaan turvallisesti.
 
 Jos sammutat järjestelmän työpöydän kautta tai komentoriviltä (esimerkiksi `shutdown`-komennolla), laite käynnistyy automaattisesti uudelleen noin viiden sekunnin kuluttua. Tämä johtuu siitä, että virranhallinta havaitsee ulkoisen virransyötön olevan yhä käytettävissä.
 
@@ -349,17 +349,17 @@ Jos haluat nopeuttaa käynnistystä tai tarvitset virtaa paljon kuluttaville ohe
 
 ##### Kaapelin valmistelu
 
-1. **Reititä virtakaapeli** HALPI2:lta virtalähteelle
+1. **Reititä virtakaapeli** HALPI2:lta virransyötölle
 2. **Jätä johtolenkit** molempiin päihin
 3. **Suojaa kaapeli** hankautumiselta ja vaurioilta
 4. **Katkaise sopivan mittaiseksi** jättäen riittävästi työvaraa
 
-##### Kytkentä virtalähteen päässä
+##### Kytkentä virransyötön päässä
 
 1. **Varmista johtimen suojaus** varaamalla 3–5 A:n johdonsuojakatkaisija tai asentamalla linjasulake
 2. **Kuori johtimien päät** sopivan matkalta
 3. **Asenna liittimet** oikealla puristustekniikalla
-4. **Kytke virtalähteeseen:**
+4. **Kytke virransyöttöön:**
     - **Punainen johdin:** plusnapa (+)
     - **Musta johdin:** miinusnapa (−)
 5. **Varmista napaisuus** yleismittarilla ennen jännitteen kytkemistä
@@ -428,7 +428,7 @@ Verkkoyhteyttä varten:
 ❌ **Ei merkkiä virrasta:**
 
 - Tarkista sulakkeen kunto ja koko
-- Tarkista virtalähteen jännite (11–32 V)
+- Tarkista virransyötön jännite (11–32 V)
 - Varmista oikea napaisuus
 - Mittaa virtakaapelien jatkuvuus
 

--- a/docs/fi/technical-reference/hardware.md
+++ b/docs/fi/technical-reference/hardware.md
@@ -25,9 +25,9 @@ Tällä sivulla ovat HALPI2:n sähköiset, mekaaniset ja ympäristöä koskevat 
 
 ## Sähköiset tiedot
 
-### Virransyöttö
+### Virtalähde
 
-Virransyöttö hyväksyy laajan tasajännitealueen ja tuottaa säädetyt 5 V:n ja 3,3 V:n jännitteet CM5:lle ja oheislaitteille. Tulosuojaukseen kuuluvat käänteisen napaisuuden suojaus (LM74800), ylijännitteen irtikytkentä 38,6 V:ssa, TVS-rajoitus sekä yhteis- ja eromuotoisten EMI-häiriöiden suodatus.
+Virtalähde hyväksyy laajan tasajännitealueen ja tuottaa säädetyt 5 V:n ja 3,3 V:n jännitteet CM5:lle ja oheislaitteille. Tulosuojaukseen kuuluvat käänteisen napaisuuden suojaus (LM74800), ylijännitteen irtikytkentä 38,6 V:ssa, TVS-rajoitus sekä yhteis- ja eromuotoisten EMI-häiriöiden suodatus.
 
 | Ominaisuus | Arvo |
 |:-----------|:-----|
@@ -245,7 +245,7 @@ Vakiokotelo jäähtyy passiivisesti ilman tuuletinta. 4-napainen PWM-tuuletinlii
 
 !!! quote "Aiheeseen liittyvää"
     - **Kytkentäkaaviot ja suunnittelutiedostot:** katso [Suunnittelutiedostot ja kytkentäkaaviot](../appendices/design-files.md)
-    - **Virranhallinnan toiminta:** katso [Virransyöttö tarkemmin](./power-supply.md)
+    - **Virranhallinnan toiminta:** katso [Virtalähde tarkemmin](./power-supply.md)
     - **Liitäntäprotokollat:** katso [Liitännät ja tiedonsiirto](./interfaces.md)
     - **Ohjain ja I2C-protokolla:** katso [Emolevyn ohjain](./controller.md)
     - **Fyysinen asennus:** katso [Laitteisto-opas](../user-guide/hardware.md)

--- a/docs/fi/technical-reference/power-supply.md
+++ b/docs/fi/technical-reference/power-supply.md
@@ -2,7 +2,7 @@
 translated_from: 5229ab5363e54a19e4330c30051e4787ece5806e
 ---
 
-# Virransyöttö tarkemmin
+# Virtalähde tarkemmin
 
 - Syöttöjännitealueet ja suojaus
 - Superkondensaattorivarmennus

--- a/docs/fi/user-guide/hardware.md
+++ b/docs/fi/user-guide/hardware.md
@@ -223,7 +223,7 @@ RS-485-liitännän saa pois käytöstä poistamalla emolevyn RX Enable -jumpperi
 
 ### Asennus
 
-Aloita sammuttamalla järjestelmä ja irrottamalla kaikki virtalähteet. Irrota kotelon kansi Kotelon käsittely -osion ohjeen mukaan.
+Aloita sammuttamalla järjestelmä ja irrottamalla kaikki virransyötöt. Irrota kotelon kansi Kotelon käsittely -osion ohjeen mukaan.
 
 Versiosta 0.5.0 alkaen emolevyillä on valmiiksi asennetut M2.5-kierreholkit HATin neljässä kiinnityskohdassa, mikä helpottaa asennusta. Vanhemmilla version 0.4.0 korteilla M2.5-mutterit on asennettava käsin. Muttereiden asentamiseksi emolevy on irrotettava väliaikaisesti. Tämä onnistuu ilman kaikkien kaapeleiden irrottamista.
 
@@ -239,7 +239,7 @@ Jos HATissa on ulkoisia liittimiä, joihin on päästävä käsiksi kotelon ulko
 
 ### Irrotus
 
-HAT irrotetaan asennuksen vastakkaisessa järjestyksessä. Sammuta järjestelmä kokonaan ja irrota kaikki virtalähteet ennen kotelon avaamista. Irrota M2.5-kiinnitysruuvit ja nosta HAT varovasti suoraan ylös GPIO-liittimestä välttäen sivusuuntaista voimaa, joka voisi taivuttaa liittimen nastoja.
+HAT irrotetaan asennuksen vastakkaisessa järjestyksessä. Sammuta järjestelmä kokonaan ja irrota kaikki virransyötöt ennen kotelon avaamista. Irrota M2.5-kiinnitysruuvit ja nosta HAT varovasti suoraan ylös GPIO-liittimestä välttäen sivusuuntaista voimaa, joka voisi taivuttaa liittimen nastoja.
 
 Jos HAT tuntuu juuttuneen, tarkista jäikö jokin kiinnitysosa tai kaapeli huomaamatta ennen kuin käytät enemmän voimaa. Jotkin tiukkaliittimiset HATit voivat vaatia varovaista keinuttamista ylöspäin vedettäessä. Keinuta HATtia pohjois–etelä-suunnassa; itä–länsi-suuntainen keinutus voi taivuttaa liittimen nastoja, kun liitin yhtäkkiä irtoaa.
 
@@ -305,7 +305,7 @@ Varaa ennen aloittamista lämmönjohtotyynyt lämmönsiirtoa varten. Vakiokokoon
 
 ### Compute Moduleen käsiksi pääsy
 
-Sammuta HALPI2 ja irrota virtalähde. Irrota kotelon kansi Kotelon käsittely -osion ohjeen mukaan. CM5 on emolevyn alapuolella, joten emolevy on ensin irrotettava kotelosta. Emolevylle tulee useita kaapeleita, joten kannattaa ottaa muutama valokuva kytkennöistä ennen jatkamista.
+Sammuta HALPI2 ja irrota virransyöttö. Irrota kotelon kansi Kotelon käsittely -osion ohjeen mukaan. CM5 on emolevyn alapuolella, joten emolevy on ensin irrotettava kotelosta. Emolevylle tulee useita kaapeleita, joten kannattaa ottaa muutama valokuva kytkennöistä ennen jatkamista.
 
 Irrota kaapelit, jotka estävät emolevyn nostamisen. Irrota emolevyn kiinnitysruuvit ja nosta kortti pois kotelosta.
 

--- a/docs/fi/user-guide/operation.md
+++ b/docs/fi/user-guide/operation.md
@@ -38,13 +38,13 @@ Käytön aikana LEDit toimivat jännitemittarina, joka näyttää superkondensaa
 
 ## Virranhallinta ja sammutus
 
-HALPI2:n virransyöttö on suunniteltu kestämään jännitepiikkejä, häiriöitä ja lyhyitä katkoja.
+HALPI2:n virtalähde on suunniteltu kestämään jännitepiikkejä, häiriöitä ja lyhyitä katkoja.
 
 ### Virransyöttöjärjestelmän yleiskuvaus
 
 HALPI2:n virranhallinta koostuu näistä osista:
 
-- **Laajan jännitealueen virransyöttö** (11–32 V DC, suojaus 100 V DC asti)
+- **Laajan jännitealueen virtalähde** (11–32 V DC, suojaus 100 V DC asti)
 - **Superkondensaattorivarmennus** hallittuun sammutukseen jännitteen katketessa
 - **Virranrajoitus** (valittavissa 0,9 A tai 2,5 A)
 - **Jännitteen menetyksen tunnistus** ja automaattinen sammutuksen käynnistys

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -65,7 +65,7 @@ plugins:
             Troubleshooting: Vianetsintä
             Technical Reference: Tekniset tiedot
             Hardware Reference: Laitteiston tekniset tiedot
-            Power Supply Deep Dive: Virransyöttö tarkemmin
+            Power Supply Deep Dive: Virtalähde tarkemmin
             Carrier Board Controller: Emolevyn ohjain
             Software Development: Ohjelmistokehitys
             HALPI2 Daemon: HALPI2-daemon


### PR DESCRIPTION
The Finnish glossary prescribes `power supply` → `virtalähde` and `power source` → `virransyöttö`. Sixteen places had them the other way round.

## Why the checker did not catch it

`check_glossary.py` was green throughout, and correctly so by its own logic: both prescribed words appear on the Finnish side. Only their English partners were swapped. The script's docstring names this exactly — *"It finds a term that is never used, not a term that has acquired a rival"* — and this is the second repository it has been found in. hatlabs/sh-rpi#27 had the same inversion, which is what prompted looking here.

Sample of what was wrong:

```
EN  - 12V or 24V power source
FI  - 12 V:n tai 24 V:n virtalähde     ← the row says virransyöttö
```

## Scope

**Fixed:** the places where English uses the term as a standalone noun — the parts list, the wiring steps, the troubleshooting check, the two `Power Supply` headings, and the `Power Supply Deep Dive` page title with its nav label and one cross-reference.

**Deliberately not touched:** Finnish `virransyöttö` also renders plain *power* in compounds that neither glossary row covers — `virransyöttöön sopivia sulakkeita` (fuses for power connections), `virransyötön ja toiminnan tilasta` (power and activity states), `virransyötön komponentit` (power supply components inside a thermal-pad instruction). Substituting term by term there would produce worse Finnish, not more consistent Finnish. The two rows govern the noun, not every compound built on the word.

## Which way the pair goes

Matti settled it on the SH-RPi branch: the inherited rows stand, and the pages follow them. I had argued the opposite from how the pages read — in both repositories — and proposed correcting the rows. That was a reading of Finnish usage, not a decision that was mine to make.

## Verification

| | |
|:--|:--|
| Structure vs. the English source | 0 deviations across 20 pages |
| `mkdocs build --strict` | clean |
| `check_anchors.py` | all anchors resolve |
| `map_anchors.py` | nothing left to remap after the heading changes |
| `check_typography.py` | clean |
| `check_glossary.py` | clean |
| `translation_status.py` | `fi: current=20` |

Only the Finnish is touched; the other eight languages are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
