### PR TITLE
Fix the manual install instructions for HALPI2

### DIFF
--- a/docs/da/software-development/ubuntu-installation.md
+++ b/docs/da/software-development/ubuntu-installation.md
@@ -1,5 +1,5 @@
 ---
-translated_from: 8c2d1560ad56e730c3fe6476cd5cf075b632b539
+translated_from: e096c9a0b090c6f3ced22a4d369daab4ad1fcadb
 ---
 
 # Brug af andre Debian-baserede distributioner
@@ -70,14 +70,26 @@ dtoverlay=mcp251xfd,spi0-1,interrupt=26,oscillator=40000000
 
 # Enable PL011 UART4.  Creates /dev/ttyAMA4 for NMEA 0183 communication.
 dtoverlay=uart4-pi5
+
+# Enable the ARM I2C bus.  The halpid daemon reaches the power management
+# controller over /dev/i2c-1.
+dtparam=i2c_arm=on
+
+# Disable the unused SD card interface.  It causes a long delay at shutdown.
+# See: https://github.com/raspberrypi/linux/issues/7014
+dtparam=sd=off
 ```
 
-Derefter skal I2C-grænsefladen aktiveres, så `halpid`-dæmonen i brugerrummet kan kommunikere med hardwaren til strømstyring.
+!!! warning "I2C skal være aktiveret"
+    I Raspberry Pi OS er `dtparam=i2c_arm=on` kommenteret ud, og andre distributioner kan gøre det samme. Uden den findes `/dev/i2c-1` ikke, og `halpid` kan ikke nå hardwaren til strømstyring.
+
+Kernemodulet `i2c-dev` skal desuden indlæses ved opstart, så `halpid`-dæmonen i brugerrummet kan bruge bussen.
 Det gøres ved at oprette filen `/etc/modules-load.d/i2c-dev.conf` med:
 
 ```bash
-sudo echo i2c-dev > /etc/modules-load.d/i2c-dev.conf
+echo i2c-dev | sudo tee /etc/modules-load.d/i2c-dev.conf
 ```
+
 ## Opsætning af CAN-bussen (NMEA 2000)
 
 Følgende kommandoer aktiverer CAN-bussen til NMEA 2000-kommunikation på HALPI2:
@@ -125,12 +137,14 @@ halpi status
 
 Nu hvor kommandoen `halpi` er tilgængelig, kan pakken `halpi2-firmware` installeres. Den flasher den nyeste firmware til HALPI2-kortet:
 ```bash
-apt install halpi2-firmware
+sudo apt install halpi2-firmware
 ```
 
-Firmwaren kan flashes manuelt med:
+Firmwaren flashes automatisk, når pakken installeres eller opgraderes. Det kan slås fra ved at sætte `AUTO_FLASH_ON_INSTALL=no` i `/etc/halpid/firmware.conf`.
+
+Pakken installerer firmware-binærfilerne under `/usr/share/halpi2-firmware/`. Hvis du vil flashe en bestemt version manuelt, skal du give `halpi flash` stien til binærfilen:
 ```bash
-halpi flash /usr/share/halpi2/firmware/halpi2-rs-firmware_VERSION.bin
+halpi flash /usr/share/halpi2-firmware/halpi2-rs-firmware_3.3.1.bin
 ```
 
 ## Opsætning af Signal K-server
@@ -171,7 +185,7 @@ Der kan du klikke på knappen `+Add` og oprette en forbindelse med mindst følge
                  ID: "HALPI2N0183"
    NMEA 0183 Source: Serial
         Serial Port: /dev/ttyAMA4
-          Baud Rate: 4800 | 34800
+          Baud Rate: 4800 | 38400
 ```
 
 Genstart, og kontrollér på dashboardet, om der modtages data.

--- a/docs/da/software-development/ubuntu-installation.md
+++ b/docs/da/software-development/ubuntu-installation.md
@@ -1,5 +1,5 @@
 ---
-translated_from: e096c9a0b090c6f3ced22a4d369daab4ad1fcadb
+translated_from: 9b2819d37e8c666f7908c658418aa61209985b55
 ---
 
 # Brug af andre Debian-baserede distributioner
@@ -52,6 +52,9 @@ exit
 
 Firmwaren til de fælles enheder på HALPI2-kortet konfigureres ved at redigere `/boot/firmware/config.txt` og tilføje følgende linjer i afsnittet `[all]`:
 
+!!! danger "Kontrollér din startenhed, før du indsætter dette"
+    Blokken nedenfor slutter med `dtparam=sd=off`. På en Compute Module 5 deaktiverer den linje det indbyggede microSD-stik og, på et modul med eMMC, også eMMC'en. Behold linjen, hvis du starter fra NVMe, som er HALPI2's standardkonfiguration. Fjern den, hvis du starter fra microSD eller eMMC, ellers starter enheden ikke efter næste genstart.
+
 ```text
 # --- HALPI2 / Raspberry Pi 5 IO setup ---
 
@@ -75,7 +78,10 @@ dtoverlay=uart4-pi5
 # controller over /dev/i2c-1.
 dtparam=i2c_arm=on
 
-# Disable the unused SD card interface.  It causes a long delay at shutdown.
+# Disable the SD interface.  Without this, shutdown stalls long enough that the
+# supercapacitors can run out before the controller powers the board down.
+# This also disables the onboard microSD slot and the eMMC on a CM5 that has
+# one, so omit the line if you boot from either.
 # See: https://github.com/raspberrypi/linux/issues/7014
 dtparam=sd=off
 ```
@@ -89,6 +95,18 @@ Det gøres ved at oprette filen `/etc/modules-load.d/i2c-dev.conf` med:
 ```bash
 echo i2c-dev | sudo tee /etc/modules-load.d/i2c-dev.conf
 ```
+
+Genstart for at aktivere ændringerne, og kontrollér derefter, at I2C-bussen findes:
+
+```bash
+sudo reboot
+```
+
+```bash
+ls /dev/i2c-1
+```
+
+Hvis `/dev/i2c-1` ikke findes, så gennemgå ændringerne i `config.txt`, før du fortsætter. `halpid`-dæmonen kan ikke starte uden den.
 
 ## Opsætning af CAN-bussen (NMEA 2000)
 
@@ -133,19 +151,28 @@ HALPI2-dæmonen bør nu køre, og kommandoen `halpi` være tilgængelig. Du kan 
 halpi status
 ```
 
+Dæmonens socket kan kun læses af gruppen `halpid`. Pakken føjer din bruger til gruppen, men medlemskabet gælder først i nye login-sessioner. Hvis kommandoen ikke kan forbinde, så log ud og ind igen, eller brug `sudo halpi status`.
+
 ## Installation af HALPI2-firmware
 
-Nu hvor kommandoen `halpi` er tilgængelig, kan pakken `halpi2-firmware` installeres. Den flasher den nyeste firmware til HALPI2-kortet:
+Nu hvor kommandoen `halpi` er tilgængelig, skal du installere pakken `halpi2-firmware`, som indeholder firmware-filerne under `/usr/share/halpi2-firmware/`:
 ```bash
 sudo apt install halpi2-firmware
 ```
 
-Firmwaren flashes automatisk, når pakken installeres eller opgraderes. Det kan slås fra ved at sætte `AUTO_FLASH_ON_INSTALL=no` i `/etc/halpid/firmware.conf`.
 
-Pakken installerer firmware-binærfilerne under `/usr/share/halpi2-firmware/`. Hvis du vil flashe en bestemt version manuelt, skal du give `halpi flash` stien til binærfilen:
+!!! warning "Flash firmwaren selv"
+    Pakken forsøger at flashe under installationen, men forsøget mislykkes lydløst i de nuværende udgivelser ([`HALPI2-firmware` #40](https://github.com/hatlabs/HALPI2-firmware/issues/40)). Apt melder alligevel om succes, så flash manuelt, og kontrollér resultatet.
+
+Flash firmwaren, og sluk derefter enheden. En genstart tager ikke den nye firmware i brug:
 ```bash
-halpi flash /usr/share/halpi2-firmware/halpi2-rs-firmware_3.3.1.bin
+sudo halpi flash /usr/share/halpi2-firmware/halpi2-rs-firmware_*.bin
+sudo shutdown -h now
 ```
+
+Tænd enheden igen, og bekræft versionen med `halpi status`. Ved en installation uden skærm skal du kunne nå afbryderen, før du kører nedlukningen.
+
+[Softwarevejledningen](../user-guide/software.md#manuel-installation-af-firmware) beskriver den automatiske opdateringsmekanisme, og hvordan den slås fra.
 
 ## Opsætning af Signal K-server
 

--- a/docs/de/software-development/ubuntu-installation.md
+++ b/docs/de/software-development/ubuntu-installation.md
@@ -1,5 +1,5 @@
 ---
-translated_from: 8c2d1560ad56e730c3fe6476cd5cf075b632b539
+translated_from: e096c9a0b090c6f3ced22a4d369daab4ad1fcadb
 ---
 
 # Andere Debian-basierte Distributionen verwenden
@@ -69,12 +69,23 @@ dtoverlay=mcp251xfd,spi0-1,interrupt=26,oscillator=40000000
 
 # Enable PL011 UART4.  Creates /dev/ttyAMA4 for NMEA 0183 communication.
 dtoverlay=uart4-pi5
+
+# Enable the ARM I2C bus.  The halpid daemon reaches the power management
+# controller over /dev/i2c-1.
+dtparam=i2c_arm=on
+
+# Disable the unused SD card interface.  It causes a long delay at shutdown.
+# See: https://github.com/raspberrypi/linux/issues/7014
+dtparam=sd=off
 ```
 
-Anschließend muss die I2C-Schnittstelle aktiviert werden, damit der im Benutzerbereich laufende Daemon `halpid` mit der Hardware der Energieverwaltung kommunizieren kann. Legen Sie dazu die Datei `/etc/modules-load.d/i2c-dev.conf` an:
+!!! warning "I2C muss aktiviert sein"
+    In Raspberry Pi OS ist `dtparam=i2c_arm=on` auskommentiert, und andere Distributionen halten es womöglich ebenso. Ohne diese Zeile gibt es kein `/dev/i2c-1`, und `halpid` erreicht die Hardware der Energieverwaltung nicht.
+
+Außerdem muss das Kernelmodul `i2c-dev` beim Start geladen werden, damit der im Benutzerbereich laufende Daemon `halpid` den Bus verwenden kann. Legen Sie dazu die Datei `/etc/modules-load.d/i2c-dev.conf` an:
 
 ```bash
-sudo echo i2c-dev > /etc/modules-load.d/i2c-dev.conf
+echo i2c-dev | sudo tee /etc/modules-load.d/i2c-dev.conf
 ```
 
 ## Einrichtung des CAN-Busses (NMEA 2000)
@@ -125,13 +136,15 @@ halpi status
 Da der Befehl `halpi` nun verfügbar ist, lässt sich das Paket `halpi2-firmware` installieren, das die neueste Firmware auf die HALPI2-Platine flasht:
 
 ```bash
-apt install halpi2-firmware
+sudo apt install halpi2-firmware
 ```
 
-Die Firmware kann auch von Hand geflasht werden:
+Die Firmware wird automatisch geflasht, sobald das Paket installiert oder aktualisiert wird. Setzen Sie `AUTO_FLASH_ON_INSTALL=no` in `/etc/halpid/firmware.conf`, um das abzuschalten.
+
+Das Paket installiert die Firmware-Binärdateien unter `/usr/share/halpi2-firmware/`. Wenn Sie eine bestimmte Version von Hand flashen wollen, geben Sie `halpi flash` den Pfad zur Binärdatei an:
 
 ```bash
-halpi flash /usr/share/halpi2/firmware/halpi2-rs-firmware_VERSION.bin
+halpi flash /usr/share/halpi2-firmware/halpi2-rs-firmware_3.3.1.bin
 ```
 
 ## Einrichtung des Signal-K-Servers
@@ -169,7 +182,7 @@ Auch für eine NMEA-0183-Verbindung benötigen Sie ein Signal-K-Administratorkon
                  ID: "HALPI2N0183"
    NMEA 0183 Source: Serial
         Serial Port: /dev/ttyAMA4
-          Baud Rate: 4800 | 34800
+          Baud Rate: 4800 | 38400
 ```
 
 Starten Sie neu und prüfen Sie im Dashboard, ob Daten eintreffen.

--- a/docs/de/software-development/ubuntu-installation.md
+++ b/docs/de/software-development/ubuntu-installation.md
@@ -1,5 +1,5 @@
 ---
-translated_from: e096c9a0b090c6f3ced22a4d369daab4ad1fcadb
+translated_from: 9b2819d37e8c666f7908c658418aa61209985b55
 ---
 
 # Andere Debian-basierte Distributionen verwenden
@@ -51,6 +51,9 @@ exit
 
 Die Firmware der gemeinsamen Komponenten auf der HALPI2-Platine wird konfiguriert, indem Sie `/boot/firmware/config.txt` bearbeiten und die folgenden Zeilen im Abschnitt `[all]` ergänzen:
 
+!!! danger "Prüfen Sie Ihr Boot-Medium, bevor Sie das einfügen"
+    Der Block unten endet mit `dtparam=sd=off`. Auf einem Compute Module 5 deaktiviert diese Zeile den integrierten microSD-Steckplatz und, auf einem Modul mit eMMC, auch die eMMC. Behalten Sie die Zeile, wenn Sie von NVMe booten — das ist die Standardkonfiguration des HALPI2. Entfernen Sie sie, wenn Sie von microSD oder eMMC booten, sonst startet das Gerät nach dem nächsten Neustart nicht mehr.
+
 ```text
 # --- HALPI2 / Raspberry Pi 5 IO setup ---
 
@@ -74,7 +77,10 @@ dtoverlay=uart4-pi5
 # controller over /dev/i2c-1.
 dtparam=i2c_arm=on
 
-# Disable the unused SD card interface.  It causes a long delay at shutdown.
+# Disable the SD interface.  Without this, shutdown stalls long enough that the
+# supercapacitors can run out before the controller powers the board down.
+# This also disables the onboard microSD slot and the eMMC on a CM5 that has
+# one, so omit the line if you boot from either.
 # See: https://github.com/raspberrypi/linux/issues/7014
 dtparam=sd=off
 ```
@@ -87,6 +93,18 @@ Außerdem muss das Kernelmodul `i2c-dev` beim Start geladen werden, damit der im
 ```bash
 echo i2c-dev | sudo tee /etc/modules-load.d/i2c-dev.conf
 ```
+
+Starten Sie neu, damit die Änderungen wirksam werden, und prüfen Sie dann, ob der I2C-Bus vorhanden ist:
+
+```bash
+sudo reboot
+```
+
+```bash
+ls /dev/i2c-1
+```
+
+Fehlt `/dev/i2c-1`, prüfen Sie die Änderungen in `config.txt`, bevor Sie fortfahren. Ohne den Bus kann der Daemon `halpid` nicht starten.
 
 ## Einrichtung des CAN-Busses (NMEA 2000)
 
@@ -131,21 +149,29 @@ Der HALPI2-Daemon sollte nun laufen und der Befehl `halpi` verfügbar sein. Den 
 halpi status
 ```
 
+Der Socket des Daemons ist nur für die Gruppe `halpid` lesbar. Das Paket nimmt Ihren Benutzer in diese Gruppe auf, die Mitgliedschaft gilt aber erst in neuen Anmeldesitzungen. Wenn der Befehl keine Verbindung herstellt, melden Sie sich ab und wieder an, oder verwenden Sie `sudo halpi status`.
+
 ## Installation der HALPI2-Firmware
 
-Da der Befehl `halpi` nun verfügbar ist, lässt sich das Paket `halpi2-firmware` installieren, das die neueste Firmware auf die HALPI2-Platine flasht:
+Da der Befehl `halpi` nun verfügbar ist, installieren Sie das Paket `halpi2-firmware`, das die Firmware-Dateien unter `/usr/share/halpi2-firmware/` mitbringt:
 
 ```bash
 sudo apt install halpi2-firmware
 ```
 
-Die Firmware wird automatisch geflasht, sobald das Paket installiert oder aktualisiert wird. Setzen Sie `AUTO_FLASH_ON_INSTALL=no` in `/etc/halpid/firmware.conf`, um das abzuschalten.
 
-Das Paket installiert die Firmware-Binärdateien unter `/usr/share/halpi2-firmware/`. Wenn Sie eine bestimmte Version von Hand flashen wollen, geben Sie `halpi flash` den Pfad zur Binärdatei an:
+!!! warning "Flashen Sie die Firmware selbst"
+    Das Paket versucht, während der Installation zu flashen, doch der Versuch scheitert in den aktuellen Versionen stillschweigend ([`HALPI2-firmware` #40](https://github.com/hatlabs/HALPI2-firmware/issues/40)). Apt meldet trotzdem Erfolg. Flashen Sie daher von Hand und prüfen Sie das Ergebnis.
 
+Flashen Sie die Firmware und schalten Sie das Gerät danach aus. Ein Neustart übernimmt die neue Firmware nicht:
 ```bash
-halpi flash /usr/share/halpi2-firmware/halpi2-rs-firmware_3.3.1.bin
+sudo halpi flash /usr/share/halpi2-firmware/halpi2-rs-firmware_*.bin
+sudo shutdown -h now
 ```
+
+Schalten Sie das Gerät wieder ein und prüfen Sie die Version mit `halpi status`. Bei einer Installation ohne Bildschirm müssen Sie den Netzschalter erreichen können, bevor Sie das Herunterfahren ausführen.
+
+Das [Software-Handbuch](../user-guide/software.md#firmware-von-hand-installieren) beschreibt den automatischen Aktualisierungsmechanismus und wie man ihn abschaltet.
 
 ## Einrichtung des Signal-K-Servers
 

--- a/docs/en/software-development/ubuntu-installation.md
+++ b/docs/en/software-development/ubuntu-installation.md
@@ -48,6 +48,9 @@ exit
 
 The firmware for common devices on the HALPI2 board can be configured by editing `/boot/firmware/config.txt` and adding the following lines to the `[all]` section:
 
+!!! danger "Check your boot device before you paste this"
+    The block below ends with `dtparam=sd=off`. On a Compute Module 5 that line disables the onboard microSD slot and, on a module with eMMC, the eMMC as well. Keep it if you boot from NVMe, which is the standard HALPI2 configuration. Remove it if you boot from microSD or eMMC, or the device will not boot after the next restart.
+
 ```text
 # --- HALPI2 / Raspberry Pi 5 IO setup ---
 
@@ -71,7 +74,10 @@ dtoverlay=uart4-pi5
 # controller over /dev/i2c-1.
 dtparam=i2c_arm=on
 
-# Disable the unused SD card interface.  It causes a long delay at shutdown.
+# Disable the SD interface.  Without this, shutdown stalls long enough that the
+# supercapacitors can run out before the controller powers the board down.
+# This also disables the onboard microSD slot and the eMMC on a CM5 that has
+# one, so omit the line if you boot from either.
 # See: https://github.com/raspberrypi/linux/issues/7014
 dtparam=sd=off
 ```
@@ -86,9 +92,21 @@ This is done by creating a file `/etc/modules-load.d/i2c-dev.conf` with:
 echo i2c-dev | sudo tee /etc/modules-load.d/i2c-dev.conf
 ```
 
+Reboot to apply the changes, then confirm that the I2C bus is present:
+
+```bash
+sudo reboot
+```
+
+```bash
+ls /dev/i2c-1
+```
+
+If `/dev/i2c-1` does not exist, revisit the `config.txt` edits before continuing. The `halpid` daemon cannot start without it.
+
 ## CAN Bus (NMEA 2000) Setup
 
-The following command with enable the CAN Bus for NMEA 2000 communication on the HALPI2:
+The following commands enable the CAN Bus for NMEA 2000 communication on the HALPI2:
 
 ```bash
 sudo bash
@@ -129,19 +147,27 @@ The HALPI2 Daemon should now be running and the `halpi` command available. You c
 halpi status
 ```
 
+The daemon socket is only readable by the `halpid` group. The package adds your user to that group, but the membership applies to new login sessions only. If the command fails to connect, log out and back in, or use `sudo halpi status`.
+
 ## HALPI2 Firmware Installation
 
-Now that the `halpi` command is available, the `halpi2-firmware` package can be installed, which will flash the latest firmware to the HALPI2 board:
+Now that the `halpi` command is available, install the `halpi2-firmware` package, which ships the firmware images under `/usr/share/halpi2-firmware/`:
 ```bash
 sudo apt install halpi2-firmware
 ```
 
-Flashing happens automatically when the package is installed or upgraded. To turn this off, set `AUTO_FLASH_ON_INSTALL=no` in `/etc/halpid/firmware.conf`.
+!!! warning "Flash the firmware yourself"
+    The package tries to flash during installation, but that attempt fails silently on current releases ([`HALPI2-firmware` #40](https://github.com/hatlabs/HALPI2-firmware/issues/40)). Apt still reports success, so flash manually and check the result.
 
-The package installs the firmware binaries under `/usr/share/halpi2-firmware/`. To flash a specific version manually, give `halpi flash` the path to the binary:
+Flash the firmware, then power the device off. A reboot does not apply the new firmware:
 ```bash
-halpi flash /usr/share/halpi2-firmware/halpi2-rs-firmware_3.3.1.bin
+sudo halpi flash /usr/share/halpi2-firmware/halpi2-rs-firmware_*.bin
+sudo shutdown -h now
 ```
+
+Power the device back on and confirm the version with `halpi status`. On a headless installation, make sure you can reach the power switch before you run the shutdown.
+
+The [software guide](../user-guide/software.md#manual-firmware-installation) describes the automatic update mechanism and how to disable it.
 
 ## Signal K Server Setup
 

--- a/docs/en/software-development/ubuntu-installation.md
+++ b/docs/en/software-development/ubuntu-installation.md
@@ -66,14 +66,26 @@ dtoverlay=mcp251xfd,spi0-1,interrupt=26,oscillator=40000000
 
 # Enable PL011 UART4.  Creates /dev/ttyAMA4 for NMEA 0183 communication.
 dtoverlay=uart4-pi5
+
+# Enable the ARM I2C bus.  The halpid daemon reaches the power management
+# controller over /dev/i2c-1.
+dtparam=i2c_arm=on
+
+# Disable the unused SD card interface.  It causes a long delay at shutdown.
+# See: https://github.com/raspberrypi/linux/issues/7014
+dtparam=sd=off
 ```
 
-Then the I2C interface needs to be enabled so that the user space `halpid` daemon can communicate with the power management hardware.
+!!! warning "I2C must be enabled"
+    Raspberry Pi OS ships `dtparam=i2c_arm=on` commented out, and other distributions may do the same. Without it there is no `/dev/i2c-1`, and `halpid` cannot reach the power management hardware.
+
+The `i2c-dev` kernel module also has to be loaded at boot so that the user space `halpid` daemon can use the bus.
 This is done by creating a file `/etc/modules-load.d/i2c-dev.conf` with:
 
 ```bash
-sudo echo i2c-dev > /etc/modules-load.d/i2c-dev.conf
+echo i2c-dev | sudo tee /etc/modules-load.d/i2c-dev.conf
 ```
+
 ## CAN Bus (NMEA 2000) Setup
 
 The following command with enable the CAN Bus for NMEA 2000 communication on the HALPI2:
@@ -121,12 +133,14 @@ halpi status
 
 Now that the `halpi` command is available, the `halpi2-firmware` package can be installed, which will flash the latest firmware to the HALPI2 board:
 ```bash
-apt install halpi2-firmware
+sudo apt install halpi2-firmware
 ```
 
-The firmware can be manually flashed with:
+Flashing happens automatically when the package is installed or upgraded. To turn this off, set `AUTO_FLASH_ON_INSTALL=no` in `/etc/halpid/firmware.conf`.
+
+The package installs the firmware binaries under `/usr/share/halpi2-firmware/`. To flash a specific version manually, give `halpi flash` the path to the binary:
 ```bash
-halpi flash /usr/share/halpi2/firmware/halpi2-rs-firmware_VERSION.bin
+halpi flash /usr/share/halpi2-firmware/halpi2-rs-firmware_3.3.1.bin
 ```
 
 ## Signal K Server Setup
@@ -167,7 +181,7 @@ There you can click the `+Add` button and create a connector with at least the f
                  ID: "HALPI2N0183"
    NMEA 0183 Source: Serial
         Serial Port: /dev/ttyAMA4
-          Baud Rate: 4800 | 34800
+          Baud Rate: 4800 | 38400
 ```
 
 Restart and check the dashboard to see if data is being received.

--- a/docs/es/software-development/ubuntu-installation.md
+++ b/docs/es/software-development/ubuntu-installation.md
@@ -1,5 +1,5 @@
 ---
-translated_from: e096c9a0b090c6f3ced22a4d369daab4ad1fcadb
+translated_from: 9b2819d37e8c666f7908c658418aa61209985b55
 ---
 
 # Uso de otras distribuciones basadas en Debian
@@ -52,6 +52,9 @@ exit
 
 El firmware de los dispositivos comunes de la placa HALPI2 se configura editando `/boot/firmware/config.txt` y añadiendo las siguientes líneas a la sección `[all]`:
 
+!!! danger "Comprobar el dispositivo de arranque antes de pegar esto"
+    El bloque siguiente termina con `dtparam=sd=off`. En un Compute Module 5 esa línea desactiva la ranura microSD integrada y, en un módulo con eMMC, también la eMMC. Conviene mantenerla si el arranque se hace desde NVMe, que es la configuración estándar del HALPI2. Hay que quitarla si el arranque se hace desde microSD o eMMC; de lo contrario el equipo no arrancará tras el siguiente reinicio.
+
 ```text
 # --- HALPI2 / Raspberry Pi 5 IO setup ---
 
@@ -75,7 +78,10 @@ dtoverlay=uart4-pi5
 # controller over /dev/i2c-1.
 dtparam=i2c_arm=on
 
-# Disable the unused SD card interface.  It causes a long delay at shutdown.
+# Disable the SD interface.  Without this, shutdown stalls long enough that the
+# supercapacitors can run out before the controller powers the board down.
+# This also disables the onboard microSD slot and the eMMC on a CM5 that has
+# one, so omit the line if you boot from either.
 # See: https://github.com/raspberrypi/linux/issues/7014
 dtparam=sd=off
 ```
@@ -89,6 +95,18 @@ Para ello se crea el archivo `/etc/modules-load.d/i2c-dev.conf` con:
 ```bash
 echo i2c-dev | sudo tee /etc/modules-load.d/i2c-dev.conf
 ```
+
+Reiniciar para aplicar los cambios y comprobar después que el bus I2C está presente:
+
+```bash
+sudo reboot
+```
+
+```bash
+ls /dev/i2c-1
+```
+
+Si `/dev/i2c-1` no existe, revisar los cambios en `config.txt` antes de continuar. El demonio `halpid` no puede arrancar sin él.
 
 ## Configuración del bus CAN (NMEA 2000)
 
@@ -133,19 +151,28 @@ El demonio HALPI2 debería estar ya en ejecución y el comando `halpi` disponibl
 halpi status
 ```
 
+El socket del demonio solo es legible para el grupo `halpid`. El paquete añade el usuario a ese grupo, pero la pertenencia se aplica solo en las nuevas sesiones de inicio. Si el comando no logra conectar, cerrar la sesión y volver a entrar, o usar `sudo halpi status`.
+
 ## Instalación del firmware de HALPI2
 
-Ahora que el comando `halpi` está disponible, puede instalarse el paquete `halpi2-firmware`, que graba el firmware más reciente en la placa del HALPI2:
+Ahora que el comando `halpi` está disponible, instalar el paquete `halpi2-firmware`, que incluye los archivos de firmware en `/usr/share/halpi2-firmware/`:
 ```bash
 sudo apt install halpi2-firmware
 ```
 
-El firmware se graba automáticamente al instalar o actualizar el paquete. Para desactivarlo, establecer `AUTO_FLASH_ON_INSTALL=no` en `/etc/halpid/firmware.conf`.
 
-El paquete instala los binarios del firmware en `/usr/share/halpi2-firmware/`. Para grabar manualmente una versión concreta, indicar a `halpi flash` la ruta del binario:
+!!! warning "Grabar el firmware manualmente"
+    El paquete intenta grabar durante la instalación, pero el intento falla de forma silenciosa en las versiones actuales ([`HALPI2-firmware` #40](https://github.com/hatlabs/HALPI2-firmware/issues/40)). Apt informa igualmente de éxito, así que conviene grabar a mano y comprobar el resultado.
+
+Grabar el firmware y apagar después el equipo. Un reinicio no aplica el firmware nuevo:
 ```bash
-halpi flash /usr/share/halpi2-firmware/halpi2-rs-firmware_3.3.1.bin
+sudo halpi flash /usr/share/halpi2-firmware/halpi2-rs-firmware_*.bin
+sudo shutdown -h now
 ```
+
+Volver a encender el equipo y confirmar la versión con `halpi status`. En una instalación sin pantalla, hay que poder alcanzar el interruptor de alimentación antes de ejecutar el apagado.
+
+La [guía del software](../user-guide/software.md#instalacion-manual-del-firmware) describe el mecanismo de actualización automática y cómo desactivarlo.
 
 ## Configuración del servidor Signal K
 

--- a/docs/es/software-development/ubuntu-installation.md
+++ b/docs/es/software-development/ubuntu-installation.md
@@ -1,5 +1,5 @@
 ---
-translated_from: 8c2d1560ad56e730c3fe6476cd5cf075b632b539
+translated_from: e096c9a0b090c6f3ced22a4d369daab4ad1fcadb
 ---
 
 # Uso de otras distribuciones basadas en Debian
@@ -70,14 +70,26 @@ dtoverlay=mcp251xfd,spi0-1,interrupt=26,oscillator=40000000
 
 # Enable PL011 UART4.  Creates /dev/ttyAMA4 for NMEA 0183 communication.
 dtoverlay=uart4-pi5
+
+# Enable the ARM I2C bus.  The halpid daemon reaches the power management
+# controller over /dev/i2c-1.
+dtparam=i2c_arm=on
+
+# Disable the unused SD card interface.  It causes a long delay at shutdown.
+# See: https://github.com/raspberrypi/linux/issues/7014
+dtparam=sd=off
 ```
 
-Después hay que habilitar la interfaz I2C para que el demonio `halpid`, que se ejecuta en espacio de usuario, pueda comunicarse con el hardware de gestión de la alimentación.
+!!! warning "El I2C debe estar habilitado"
+    En Raspberry Pi OS, `dtparam=i2c_arm=on` está comentado, y otras distribuciones pueden hacer lo mismo. Sin esa línea no existe `/dev/i2c-1` y `halpid` no alcanza el hardware de gestión de la alimentación.
+
+Además, el módulo del kernel `i2c-dev` debe cargarse en el arranque para que el demonio `halpid`, que se ejecuta en espacio de usuario, pueda usar el bus.
 Para ello se crea el archivo `/etc/modules-load.d/i2c-dev.conf` con:
 
 ```bash
-sudo echo i2c-dev > /etc/modules-load.d/i2c-dev.conf
+echo i2c-dev | sudo tee /etc/modules-load.d/i2c-dev.conf
 ```
+
 ## Configuración del bus CAN (NMEA 2000)
 
 El siguiente comando habilita el bus CAN para la comunicación NMEA 2000 en el HALPI2:
@@ -125,12 +137,14 @@ halpi status
 
 Ahora que el comando `halpi` está disponible, puede instalarse el paquete `halpi2-firmware`, que graba el firmware más reciente en la placa del HALPI2:
 ```bash
-apt install halpi2-firmware
+sudo apt install halpi2-firmware
 ```
 
-El firmware puede grabarse manualmente con:
+El firmware se graba automáticamente al instalar o actualizar el paquete. Para desactivarlo, establecer `AUTO_FLASH_ON_INSTALL=no` en `/etc/halpid/firmware.conf`.
+
+El paquete instala los binarios del firmware en `/usr/share/halpi2-firmware/`. Para grabar manualmente una versión concreta, indicar a `halpi flash` la ruta del binario:
 ```bash
-halpi flash /usr/share/halpi2/firmware/halpi2-rs-firmware_VERSION.bin
+halpi flash /usr/share/halpi2-firmware/halpi2-rs-firmware_3.3.1.bin
 ```
 
 ## Configuración del servidor Signal K
@@ -171,7 +185,7 @@ Allí se puede pulsar el botón `+Add` y crear un conector con al menos las sigu
                  ID: "HALPI2N0183"
    NMEA 0183 Source: Serial
         Serial Port: /dev/ttyAMA4
-          Baud Rate: 4800 | 34800
+          Baud Rate: 4800 | 38400
 ```
 
 Reiniciar y comprobar en el panel de control si se están recibiendo datos.

--- a/docs/fi/software-development/ubuntu-installation.md
+++ b/docs/fi/software-development/ubuntu-installation.md
@@ -1,5 +1,5 @@
 ---
-translated_from: 8c2d1560ad56e730c3fe6476cd5cf075b632b539
+translated_from: e096c9a0b090c6f3ced22a4d369daab4ad1fcadb
 ---
 
 # Muiden Debian-pohjaisten jakeluiden käyttö
@@ -69,12 +69,23 @@ dtoverlay=mcp251xfd,spi0-1,interrupt=26,oscillator=40000000
 
 # Enable PL011 UART4.  Creates /dev/ttyAMA4 for NMEA 0183 communication.
 dtoverlay=uart4-pi5
+
+# Enable the ARM I2C bus.  The halpid daemon reaches the power management
+# controller over /dev/i2c-1.
+dtparam=i2c_arm=on
+
+# Disable the unused SD card interface.  It causes a long delay at shutdown.
+# See: https://github.com/raspberrypi/linux/issues/7014
+dtparam=sd=off
 ```
 
-Tämän jälkeen I2C-liitäntä on otettava käyttöön, jotta käyttäjätilan `halpid`-daemon voi keskustella virranhallintalaitteiston kanssa. Tämä tehdään luomalla tiedosto `/etc/modules-load.d/i2c-dev.conf`:
+!!! warning "I2C on otettava käyttöön"
+    Raspberry Pi OS:ssä `dtparam=i2c_arm=on` on kommentoitu pois, ja muissa jakeluissa tilanne voi olla sama. Ilman sitä `/dev/i2c-1` ei ilmesty, eikä `halpid` tavoita virranhallintalaitteistoa.
+
+Myös `i2c-dev`-ydinmoduuli on ladattava käynnistyksen yhteydessä, jotta käyttäjätilan `halpid`-daemon voi käyttää väylää. Tämä tehdään luomalla tiedosto `/etc/modules-load.d/i2c-dev.conf`:
 
 ```bash
-sudo echo i2c-dev > /etc/modules-load.d/i2c-dev.conf
+echo i2c-dev | sudo tee /etc/modules-load.d/i2c-dev.conf
 ```
 
 ## CAN-väylän (NMEA 2000) asetukset
@@ -125,13 +136,15 @@ halpi status
 Nyt kun `halpi`-komento on käytettävissä, voidaan asentaa `halpi2-firmware`-paketti, joka flashaa uusimman firmwaren HALPI2-kortille:
 
 ```bash
-apt install halpi2-firmware
+sudo apt install halpi2-firmware
 ```
 
-Firmwaren voi flashata käsin komennolla:
+Firmware flashataan automaattisesti, kun paketti asennetaan tai päivitetään. Toiminnon voi poistaa käytöstä asettamalla `AUTO_FLASH_ON_INSTALL=no` tiedostoon `/etc/halpid/firmware.conf`.
+
+Paketti asentaa firmware-binäärit hakemistoon `/usr/share/halpi2-firmware/`. Jos haluat flashata tietyn version käsin, anna `halpi flash` -komennolle binäärin polku:
 
 ```bash
-halpi flash /usr/share/halpi2/firmware/halpi2-rs-firmware_VERSION.bin
+halpi flash /usr/share/halpi2-firmware/halpi2-rs-firmware_3.3.1.bin
 ```
 
 ## Signal K -palvelimen asetukset
@@ -169,7 +182,7 @@ NMEA 0183 -yhteyden luominen edellyttää niin ikään Signal K:n ylläpitäjät
                  ID: "HALPI2N0183"
    NMEA 0183 Source: Serial
         Serial Port: /dev/ttyAMA4
-          Baud Rate: 4800 | 34800
+          Baud Rate: 4800 | 38400
 ```
 
 Käynnistä uudelleen ja tarkista koontinäytöltä, saapuuko dataa.

--- a/docs/fi/software-development/ubuntu-installation.md
+++ b/docs/fi/software-development/ubuntu-installation.md
@@ -1,5 +1,5 @@
 ---
-translated_from: e096c9a0b090c6f3ced22a4d369daab4ad1fcadb
+translated_from: 9b2819d37e8c666f7908c658418aa61209985b55
 ---
 
 # Muiden Debian-pohjaisten jakeluiden käyttö
@@ -51,6 +51,9 @@ exit
 
 HALPI2-kortin yleisten laitteiden firmware määritetään muokkaamalla tiedostoa `/boot/firmware/config.txt` ja lisäämällä seuraavat rivit `[all]`-osioon:
 
+!!! danger "Tarkista käynnistyslaite ennen kuin liität tämän"
+    Alla oleva lohko päättyy riviin `dtparam=sd=off`. Compute Module 5:llä tämä rivi poistaa käytöstä kortilla olevan microSD-paikan ja, jos moduulissa on eMMC, myös eMMC:n. Säilytä rivi, jos käynnistät NVMe-levyltä — se on HALPI2:n vakiokokoonpano. Poista rivi, jos käynnistät microSD-kortilta tai eMMC:ltä, muuten laite ei käynnisty seuraavan uudelleenkäynnistyksen jälkeen.
+
 ```text
 # --- HALPI2 / Raspberry Pi 5 IO setup ---
 
@@ -74,7 +77,10 @@ dtoverlay=uart4-pi5
 # controller over /dev/i2c-1.
 dtparam=i2c_arm=on
 
-# Disable the unused SD card interface.  It causes a long delay at shutdown.
+# Disable the SD interface.  Without this, shutdown stalls long enough that the
+# supercapacitors can run out before the controller powers the board down.
+# This also disables the onboard microSD slot and the eMMC on a CM5 that has
+# one, so omit the line if you boot from either.
 # See: https://github.com/raspberrypi/linux/issues/7014
 dtparam=sd=off
 ```
@@ -87,6 +93,18 @@ Myös `i2c-dev`-ydinmoduuli on ladattava käynnistyksen yhteydessä, jotta käyt
 ```bash
 echo i2c-dev | sudo tee /etc/modules-load.d/i2c-dev.conf
 ```
+
+Käynnistä laite uudelleen, jotta muutokset tulevat voimaan, ja tarkista sitten että I2C-väylä on olemassa:
+
+```bash
+sudo reboot
+```
+
+```bash
+ls /dev/i2c-1
+```
+
+Jos `/dev/i2c-1` puuttuu, tarkista `config.txt`-muutokset ennen jatkamista. `halpid`-daemon ei käynnisty ilman sitä.
 
 ## CAN-väylän (NMEA 2000) asetukset
 
@@ -131,21 +149,29 @@ HALPI2-daemonin pitäisi nyt olla käynnissä ja `halpi`-komennon käytettäviss
 halpi status
 ```
 
+Daemonin soketti on luettavissa vain `halpid`-ryhmälle. Paketti lisää käyttäjäsi tähän ryhmään, mutta jäsenyys tulee voimaan vasta uusissa kirjautumisistunnoissa. Jos yhteys ei muodostu, kirjaudu ulos ja takaisin sisään tai käytä komentoa `sudo halpi status`.
+
 ## HALPI2:n firmwaren asennus
 
-Nyt kun `halpi`-komento on käytettävissä, voidaan asentaa `halpi2-firmware`-paketti, joka flashaa uusimman firmwaren HALPI2-kortille:
+Nyt kun `halpi`-komento on käytettävissä, asenna `halpi2-firmware`-paketti, joka sisältää firmware-tiedostot hakemistossa `/usr/share/halpi2-firmware/`:
 
 ```bash
 sudo apt install halpi2-firmware
 ```
 
-Firmware flashataan automaattisesti, kun paketti asennetaan tai päivitetään. Toiminnon voi poistaa käytöstä asettamalla `AUTO_FLASH_ON_INSTALL=no` tiedostoon `/etc/halpid/firmware.conf`.
 
-Paketti asentaa firmware-binäärit hakemistoon `/usr/share/halpi2-firmware/`. Jos haluat flashata tietyn version käsin, anna `halpi flash` -komennolle binäärin polku:
+!!! warning "Flashaa firmware itse"
+    Paketti yrittää flashata firmwaren asennuksen aikana, mutta yritys epäonnistuu huomaamatta nykyisissä julkaisuissa ([`HALPI2-firmware` #40](https://github.com/hatlabs/HALPI2-firmware/issues/40)). Apt ilmoittaa silti onnistumisesta, joten flashaa käsin ja tarkista tulos.
 
+Flashaa firmware ja katkaise sitten laitteesta virta. Uudelleenkäynnistys ei ota uutta firmwarea käyttöön:
 ```bash
-halpi flash /usr/share/halpi2-firmware/halpi2-rs-firmware_3.3.1.bin
+sudo halpi flash /usr/share/halpi2-firmware/halpi2-rs-firmware_*.bin
+sudo shutdown -h now
 ```
+
+Kytke virta takaisin ja varmista versio komennolla `halpi status`. Jos asennus on ilman näyttöä, varmista että pääset käsiksi virtakytkimeen ennen sammutuksen ajamista.
+
+[Ohjelmisto-opas](../user-guide/software.md#firmwaren-asennus-kasin) kuvaa automaattisen päivitysmekanismin ja sen poistamisen käytöstä.
 
 ## Signal K -palvelimen asetukset
 

--- a/docs/fr/software-development/ubuntu-installation.md
+++ b/docs/fr/software-development/ubuntu-installation.md
@@ -1,5 +1,5 @@
 ---
-translated_from: 8c2d1560ad56e730c3fe6476cd5cf075b632b539
+translated_from: e096c9a0b090c6f3ced22a4d369daab4ad1fcadb
 ---
 
 # Utiliser d'autres distributions basées sur Debian
@@ -69,12 +69,23 @@ dtoverlay=mcp251xfd,spi0-1,interrupt=26,oscillator=40000000
 
 # Enable PL011 UART4.  Creates /dev/ttyAMA4 for NMEA 0183 communication.
 dtoverlay=uart4-pi5
+
+# Enable the ARM I2C bus.  The halpid daemon reaches the power management
+# controller over /dev/i2c-1.
+dtparam=i2c_arm=on
+
+# Disable the unused SD card interface.  It causes a long delay at shutdown.
+# See: https://github.com/raspberrypi/linux/issues/7014
+dtparam=sd=off
 ```
 
-L'interface I2C doit ensuite être activée pour que le démon `halpid`, qui s'exécute en espace utilisateur, puisse dialoguer avec le matériel de gestion de l'alimentation. Créez pour cela le fichier `/etc/modules-load.d/i2c-dev.conf` :
+!!! warning "L'I2C doit être activé"
+    Sur Raspberry Pi OS, `dtparam=i2c_arm=on` est en commentaire, et d'autres distributions peuvent faire de même. Sans cette ligne, `/dev/i2c-1` n'existe pas et `halpid` n'atteint pas le matériel de gestion de l'alimentation.
+
+Le module du noyau `i2c-dev` doit en outre être chargé au démarrage pour que le démon `halpid`, qui s'exécute en espace utilisateur, puisse utiliser le bus. Créez pour cela le fichier `/etc/modules-load.d/i2c-dev.conf` :
 
 ```bash
-sudo echo i2c-dev > /etc/modules-load.d/i2c-dev.conf
+echo i2c-dev | sudo tee /etc/modules-load.d/i2c-dev.conf
 ```
 
 ## Configuration du bus CAN (NMEA 2000)
@@ -125,13 +136,15 @@ halpi status
 Maintenant que la commande `halpi` est disponible, vous pouvez installer le paquet `halpi2-firmware`, qui flashe le firmware le plus récent sur la carte HALPI2 :
 
 ```bash
-apt install halpi2-firmware
+sudo apt install halpi2-firmware
 ```
 
-Le firmware peut aussi être flashé manuellement :
+Le firmware est flashé automatiquement lors de l'installation ou de la mise à jour du paquet. Pour désactiver ce comportement, mettez `AUTO_FLASH_ON_INSTALL=no` dans `/etc/halpid/firmware.conf`.
+
+Le paquet installe les binaires du firmware dans `/usr/share/halpi2-firmware/`. Pour flasher manuellement une version précise, indiquez à `halpi flash` le chemin du binaire :
 
 ```bash
-halpi flash /usr/share/halpi2/firmware/halpi2-rs-firmware_VERSION.bin
+halpi flash /usr/share/halpi2-firmware/halpi2-rs-firmware_3.3.1.bin
 ```
 
 ## Configuration du serveur Signal K
@@ -169,7 +182,7 @@ Créer une connexion NMEA 0183 nécessite également un compte administrateur Si
                  ID: "HALPI2N0183"
    NMEA 0183 Source: Serial
         Serial Port: /dev/ttyAMA4
-          Baud Rate: 4800 | 34800
+          Baud Rate: 4800 | 38400
 ```
 
 Redémarrez, puis vérifiez sur le tableau de bord que des données arrivent.

--- a/docs/fr/software-development/ubuntu-installation.md
+++ b/docs/fr/software-development/ubuntu-installation.md
@@ -1,5 +1,5 @@
 ---
-translated_from: e096c9a0b090c6f3ced22a4d369daab4ad1fcadb
+translated_from: 9b2819d37e8c666f7908c658418aa61209985b55
 ---
 
 # Utiliser d'autres distributions basées sur Debian
@@ -51,6 +51,9 @@ exit
 
 Le firmware des périphériques communs de la carte HALPI2 se configure en modifiant `/boot/firmware/config.txt` et en ajoutant les lignes suivantes dans la section `[all]` :
 
+!!! danger "Vérifiez votre périphérique de démarrage avant de coller ceci"
+    Le bloc ci-dessous se termine par `dtparam=sd=off`. Sur un Compute Module 5, cette ligne désactive le lecteur microSD intégré et, sur un module doté d'eMMC, l'eMMC également. Conservez-la si vous démarrez depuis un NVMe, ce qui est la configuration standard du HALPI2. Supprimez-la si vous démarrez depuis la microSD ou l'eMMC, sans quoi l'appareil ne démarrera plus au prochain redémarrage.
+
 ```text
 # --- HALPI2 / Raspberry Pi 5 IO setup ---
 
@@ -74,7 +77,10 @@ dtoverlay=uart4-pi5
 # controller over /dev/i2c-1.
 dtparam=i2c_arm=on
 
-# Disable the unused SD card interface.  It causes a long delay at shutdown.
+# Disable the SD interface.  Without this, shutdown stalls long enough that the
+# supercapacitors can run out before the controller powers the board down.
+# This also disables the onboard microSD slot and the eMMC on a CM5 that has
+# one, so omit the line if you boot from either.
 # See: https://github.com/raspberrypi/linux/issues/7014
 dtparam=sd=off
 ```
@@ -87,6 +93,18 @@ Le module du noyau `i2c-dev` doit en outre être chargé au démarrage pour que 
 ```bash
 echo i2c-dev | sudo tee /etc/modules-load.d/i2c-dev.conf
 ```
+
+Redémarrez pour appliquer les changements, puis vérifiez que le bus I2C est présent :
+
+```bash
+sudo reboot
+```
+
+```bash
+ls /dev/i2c-1
+```
+
+Si `/dev/i2c-1` n'existe pas, reprenez les modifications de `config.txt` avant de continuer. Le démon `halpid` ne peut pas démarrer sans lui.
 
 ## Configuration du bus CAN (NMEA 2000)
 
@@ -131,21 +149,29 @@ Le démon HALPI2 devrait maintenant être en cours d'exécution et la commande `
 halpi status
 ```
 
+Le socket du démon n'est lisible que par le groupe `halpid`. Le paquet ajoute votre utilisateur à ce groupe, mais l'appartenance ne prend effet que dans les nouvelles sessions. Si la commande n'arrive pas à se connecter, déconnectez-vous puis reconnectez-vous, ou utilisez `sudo halpi status`.
+
 ## Installation du firmware du HALPI2
 
-Maintenant que la commande `halpi` est disponible, vous pouvez installer le paquet `halpi2-firmware`, qui flashe le firmware le plus récent sur la carte HALPI2 :
+Maintenant que la commande `halpi` est disponible, installez le paquet `halpi2-firmware`, qui fournit les fichiers de firmware dans `/usr/share/halpi2-firmware/` :
 
 ```bash
 sudo apt install halpi2-firmware
 ```
 
-Le firmware est flashé automatiquement lors de l'installation ou de la mise à jour du paquet. Pour désactiver ce comportement, mettez `AUTO_FLASH_ON_INSTALL=no` dans `/etc/halpid/firmware.conf`.
 
-Le paquet installe les binaires du firmware dans `/usr/share/halpi2-firmware/`. Pour flasher manuellement une version précise, indiquez à `halpi flash` le chemin du binaire :
+!!! warning "Flashez le firmware vous-même"
+    Le paquet tente de flasher pendant l'installation, mais la tentative échoue silencieusement dans les versions actuelles ([`HALPI2-firmware` #40](https://github.com/hatlabs/HALPI2-firmware/issues/40)). Apt signale malgré tout une réussite : flashez donc manuellement et vérifiez le résultat.
 
+Flashez le firmware, puis mettez l'appareil hors tension. Un redémarrage n'applique pas le nouveau firmware :
 ```bash
-halpi flash /usr/share/halpi2-firmware/halpi2-rs-firmware_3.3.1.bin
+sudo halpi flash /usr/share/halpi2-firmware/halpi2-rs-firmware_*.bin
+sudo shutdown -h now
 ```
+
+Remettez l'appareil sous tension et vérifiez la version avec `halpi status`. Sur une installation sans écran, assurez-vous de pouvoir atteindre l'interrupteur avant de lancer l'arrêt.
+
+Le [guide logiciel](../user-guide/software.md#installation-manuelle-du-firmware) décrit le mécanisme de mise à jour automatique et la façon de le désactiver.
 
 ## Configuration du serveur Signal K
 

--- a/docs/it/software-development/ubuntu-installation.md
+++ b/docs/it/software-development/ubuntu-installation.md
@@ -1,5 +1,5 @@
 ---
-translated_from: e096c9a0b090c6f3ced22a4d369daab4ad1fcadb
+translated_from: 9b2819d37e8c666f7908c658418aa61209985b55
 ---
 
 # Utilizzo di altre distribuzioni basate su Debian
@@ -52,6 +52,9 @@ exit
 
 Il firmware dei dispositivi comuni presenti sulla scheda HALPI2 può essere configurato modificando `/boot/firmware/config.txt` e aggiungendo le righe seguenti alla sezione `[all]`:
 
+!!! danger "Verificare il dispositivo di avvio prima di incollare"
+    Il blocco seguente termina con `dtparam=sd=off`. Su un Compute Module 5 questa riga disabilita lo slot microSD integrato e, su un modulo con eMMC, anche l’eMMC. Conviene mantenerla se l’avvio avviene da NVMe, che è la configurazione standard di HALPI2. Va rimossa se l’avvio avviene da microSD o eMMC, altrimenti il dispositivo non si avvia dopo il riavvio successivo.
+
 ```text
 # --- HALPI2 / Raspberry Pi 5 IO setup ---
 
@@ -75,7 +78,10 @@ dtoverlay=uart4-pi5
 # controller over /dev/i2c-1.
 dtparam=i2c_arm=on
 
-# Disable the unused SD card interface.  It causes a long delay at shutdown.
+# Disable the SD interface.  Without this, shutdown stalls long enough that the
+# supercapacitors can run out before the controller powers the board down.
+# This also disables the onboard microSD slot and the eMMC on a CM5 that has
+# one, so omit the line if you boot from either.
 # See: https://github.com/raspberrypi/linux/issues/7014
 dtparam=sd=off
 ```
@@ -89,6 +95,18 @@ A tale scopo si crea il file `/etc/modules-load.d/i2c-dev.conf` con:
 ```bash
 echo i2c-dev | sudo tee /etc/modules-load.d/i2c-dev.conf
 ```
+
+Riavviare per applicare le modifiche, quindi verificare che il bus I2C sia presente:
+
+```bash
+sudo reboot
+```
+
+```bash
+ls /dev/i2c-1
+```
+
+Se `/dev/i2c-1` non esiste, rivedere le modifiche a `config.txt` prima di proseguire. Il demone `halpid` non può avviarsi senza di esso.
 
 ## Configurazione del bus CAN (NMEA 2000)
 
@@ -133,19 +151,28 @@ A questo punto il demone HALPI2 dovrebbe essere in esecuzione e il comando `halp
 halpi status
 ```
 
+Il socket del demone è leggibile solo dal gruppo `halpid`. Il pacchetto aggiunge l’utente a quel gruppo, ma l’appartenenza vale solo per le nuove sessioni di accesso. Se il comando non riesce a connettersi, disconnettersi e rientrare, oppure usare `sudo halpi status`.
+
 ## Installazione del firmware di HALPI2
 
-Ora che il comando `halpi` è disponibile, si può installare il pacchetto `halpi2-firmware`, che flasherà il firmware più recente sulla scheda HALPI2:
+Ora che il comando `halpi` è disponibile, installare il pacchetto `halpi2-firmware`, che fornisce i file del firmware in `/usr/share/halpi2-firmware/`:
 ```bash
 sudo apt install halpi2-firmware
 ```
 
-Il firmware viene flashato automaticamente quando il pacchetto viene installato o aggiornato. Per disattivare questo comportamento, impostare `AUTO_FLASH_ON_INSTALL=no` in `/etc/halpid/firmware.conf`.
 
-Il pacchetto installa i binari del firmware in `/usr/share/halpi2-firmware/`. Per flashare manualmente una versione specifica, indicare a `halpi flash` il percorso del binario:
+!!! warning "Flashare il firmware manualmente"
+    Il pacchetto tenta di flashare durante l’installazione, ma il tentativo fallisce silenziosamente nelle versioni attuali ([`HALPI2-firmware` #40](https://github.com/hatlabs/HALPI2-firmware/issues/40)). Apt segnala comunque un esito positivo, quindi conviene flashare a mano e verificare il risultato.
+
+Flashare il firmware, quindi spegnere il dispositivo. Un riavvio non applica il nuovo firmware:
 ```bash
-halpi flash /usr/share/halpi2-firmware/halpi2-rs-firmware_3.3.1.bin
+sudo halpi flash /usr/share/halpi2-firmware/halpi2-rs-firmware_*.bin
+sudo shutdown -h now
 ```
+
+Riaccendere il dispositivo e verificare la versione con `halpi status`. In un’installazione senza monitor, occorre poter raggiungere l’interruttore di alimentazione prima di eseguire lo spegnimento.
+
+La [guida al software](../user-guide/software.md#installazione-manuale-del-firmware) descrive il meccanismo di aggiornamento automatico e come disattivarlo.
 
 ## Configurazione del server Signal K
 

--- a/docs/it/software-development/ubuntu-installation.md
+++ b/docs/it/software-development/ubuntu-installation.md
@@ -1,5 +1,5 @@
 ---
-translated_from: 8c2d1560ad56e730c3fe6476cd5cf075b632b539
+translated_from: e096c9a0b090c6f3ced22a4d369daab4ad1fcadb
 ---
 
 # Utilizzo di altre distribuzioni basate su Debian
@@ -70,14 +70,26 @@ dtoverlay=mcp251xfd,spi0-1,interrupt=26,oscillator=40000000
 
 # Enable PL011 UART4.  Creates /dev/ttyAMA4 for NMEA 0183 communication.
 dtoverlay=uart4-pi5
+
+# Enable the ARM I2C bus.  The halpid daemon reaches the power management
+# controller over /dev/i2c-1.
+dtparam=i2c_arm=on
+
+# Disable the unused SD card interface.  It causes a long delay at shutdown.
+# See: https://github.com/raspberrypi/linux/issues/7014
+dtparam=sd=off
 ```
 
-È quindi necessario abilitare l’interfaccia I2C, affinché il demone `halpid` in spazio utente possa comunicare con l’hardware di gestione dell’alimentazione.
+!!! warning "L’I2C deve essere abilitato"
+    In Raspberry Pi OS `dtparam=i2c_arm=on` è commentata, e altre distribuzioni possono fare lo stesso. Senza quella riga `/dev/i2c-1` non esiste e `halpid` non raggiunge l’hardware di gestione dell’alimentazione.
+
+È inoltre necessario caricare all’avvio il modulo del kernel `i2c-dev`, affinché il demone `halpid` in spazio utente possa usare il bus.
 A tale scopo si crea il file `/etc/modules-load.d/i2c-dev.conf` con:
 
 ```bash
-sudo echo i2c-dev > /etc/modules-load.d/i2c-dev.conf
+echo i2c-dev | sudo tee /etc/modules-load.d/i2c-dev.conf
 ```
+
 ## Configurazione del bus CAN (NMEA 2000)
 
 I comandi seguenti abilitano il bus CAN per la comunicazione NMEA 2000 su HALPI2:
@@ -125,12 +137,14 @@ halpi status
 
 Ora che il comando `halpi` è disponibile, si può installare il pacchetto `halpi2-firmware`, che flasherà il firmware più recente sulla scheda HALPI2:
 ```bash
-apt install halpi2-firmware
+sudo apt install halpi2-firmware
 ```
 
-Il firmware può essere flashato manualmente con:
+Il firmware viene flashato automaticamente quando il pacchetto viene installato o aggiornato. Per disattivare questo comportamento, impostare `AUTO_FLASH_ON_INSTALL=no` in `/etc/halpid/firmware.conf`.
+
+Il pacchetto installa i binari del firmware in `/usr/share/halpi2-firmware/`. Per flashare manualmente una versione specifica, indicare a `halpi flash` il percorso del binario:
 ```bash
-halpi flash /usr/share/halpi2/firmware/halpi2-rs-firmware_VERSION.bin
+halpi flash /usr/share/halpi2-firmware/halpi2-rs-firmware_3.3.1.bin
 ```
 
 ## Configurazione del server Signal K
@@ -171,7 +185,7 @@ Da lì si può fare clic sul pulsante `+Add` e creare un connettore almeno con l
                  ID: "HALPI2N0183"
    NMEA 0183 Source: Serial
         Serial Port: /dev/ttyAMA4
-          Baud Rate: 4800 | 34800
+          Baud Rate: 4800 | 38400
 ```
 
 Riavviare e controllare la dashboard per verificare se i dati vengono ricevuti.

--- a/docs/nb/software-development/ubuntu-installation.md
+++ b/docs/nb/software-development/ubuntu-installation.md
@@ -1,5 +1,5 @@
 ---
-translated_from: 8c2d1560ad56e730c3fe6476cd5cf075b632b539
+translated_from: e096c9a0b090c6f3ced22a4d369daab4ad1fcadb
 ---
 
 # Bruk av andre Debian-baserte distribusjoner
@@ -70,14 +70,26 @@ dtoverlay=mcp251xfd,spi0-1,interrupt=26,oscillator=40000000
 
 # Enable PL011 UART4.  Creates /dev/ttyAMA4 for NMEA 0183 communication.
 dtoverlay=uart4-pi5
+
+# Enable the ARM I2C bus.  The halpid daemon reaches the power management
+# controller over /dev/i2c-1.
+dtparam=i2c_arm=on
+
+# Disable the unused SD card interface.  It causes a long delay at shutdown.
+# See: https://github.com/raspberrypi/linux/issues/7014
+dtparam=sd=off
 ```
 
-Deretter må I2C-grensesnittet aktiveres, slik at daemonen `halpid` i brukerrommet (user space) kan kommunisere med maskinvaren for strømstyring.
+!!! warning "I2C må være aktivert"
+    I Raspberry Pi OS er `dtparam=i2c_arm=on` kommentert ut, og andre distribusjoner kan gjøre det samme. Uten den finnes ikke `/dev/i2c-1`, og `halpid` når ikke maskinvaren for strømstyring.
+
+Kjernemodulen `i2c-dev` må dessuten lastes ved oppstart, slik at daemonen `halpid` i brukerrommet (user space) kan bruke bussen.
 Det gjør du ved å opprette filen `/etc/modules-load.d/i2c-dev.conf` med:
 
 ```bash
-sudo echo i2c-dev > /etc/modules-load.d/i2c-dev.conf
+echo i2c-dev | sudo tee /etc/modules-load.d/i2c-dev.conf
 ```
+
 ## Oppsett av CAN-buss (NMEA 2000)
 
 Følgende kommandoer aktiverer CAN-bussen for NMEA 2000-kommunikasjon på HALPI2:
@@ -125,12 +137,14 @@ halpi status
 
 Nå som kommandoen `halpi` er tilgjengelig, kan pakken `halpi2-firmware` installeres. Den flasher den nyeste firmwaren til HALPI2-kortet:
 ```bash
-apt install halpi2-firmware
+sudo apt install halpi2-firmware
 ```
 
-Firmwaren kan flashes manuelt med:
+Firmwaren flashes automatisk når pakken installeres eller oppgraderes. Det kan slås av ved å sette `AUTO_FLASH_ON_INSTALL=no` i `/etc/halpid/firmware.conf`.
+
+Pakken installerer firmware-binærfilene under `/usr/share/halpi2-firmware/`. Hvis du vil flashe en bestemt versjon manuelt, gir du `halpi flash` stien til binærfilen:
 ```bash
-halpi flash /usr/share/halpi2/firmware/halpi2-rs-firmware_VERSION.bin
+halpi flash /usr/share/halpi2-firmware/halpi2-rs-firmware_3.3.1.bin
 ```
 
 ## Oppsett av Signal K-server
@@ -171,7 +185,7 @@ Der kan du klikke på knappen `+Add` og opprette en tilkobling med minst disse e
                  ID: "HALPI2N0183"
    NMEA 0183 Source: Serial
         Serial Port: /dev/ttyAMA4
-          Baud Rate: 4800 | 34800
+          Baud Rate: 4800 | 38400
 ```
 
 Start på nytt og sjekk dashbordet for å se om det kommer inn data.

--- a/docs/nb/software-development/ubuntu-installation.md
+++ b/docs/nb/software-development/ubuntu-installation.md
@@ -1,5 +1,5 @@
 ---
-translated_from: e096c9a0b090c6f3ced22a4d369daab4ad1fcadb
+translated_from: 9b2819d37e8c666f7908c658418aa61209985b55
 ---
 
 # Bruk av andre Debian-baserte distribusjoner
@@ -52,6 +52,9 @@ exit
 
 Firmwaren for de vanlige enhetene på HALPI2-kortet konfigureres ved å redigere `/boot/firmware/config.txt` og legge til følgende linjer i `[all]`-avsnittet:
 
+!!! danger "Kontroller oppstartsenheten før du limer inn dette"
+    Blokken nedenfor slutter med `dtparam=sd=off`. På en Compute Module 5 deaktiverer den linjen det innebygde microSD-sporet og, på en modul med eMMC, også eMMC-en. Behold linjen hvis du starter opp fra NVMe, som er standardoppsettet for HALPI2. Fjern den hvis du starter opp fra microSD eller eMMC, ellers starter ikke enheten etter neste omstart.
+
 ```text
 # --- HALPI2 / Raspberry Pi 5 IO setup ---
 
@@ -75,7 +78,10 @@ dtoverlay=uart4-pi5
 # controller over /dev/i2c-1.
 dtparam=i2c_arm=on
 
-# Disable the unused SD card interface.  It causes a long delay at shutdown.
+# Disable the SD interface.  Without this, shutdown stalls long enough that the
+# supercapacitors can run out before the controller powers the board down.
+# This also disables the onboard microSD slot and the eMMC on a CM5 that has
+# one, so omit the line if you boot from either.
 # See: https://github.com/raspberrypi/linux/issues/7014
 dtparam=sd=off
 ```
@@ -89,6 +95,18 @@ Det gjør du ved å opprette filen `/etc/modules-load.d/i2c-dev.conf` med:
 ```bash
 echo i2c-dev | sudo tee /etc/modules-load.d/i2c-dev.conf
 ```
+
+Start på nytt for å ta i bruk endringene, og kontroller deretter at I2C-bussen finnes:
+
+```bash
+sudo reboot
+```
+
+```bash
+ls /dev/i2c-1
+```
+
+Hvis `/dev/i2c-1` mangler, gå gjennom endringene i `config.txt` før du fortsetter. Daemonen `halpid` kan ikke starte uten den.
 
 ## Oppsett av CAN-buss (NMEA 2000)
 
@@ -133,19 +151,28 @@ HALPI2-daemonen skal nå kjøre, og kommandoen `halpi` skal være tilgjengelig. 
 halpi status
 ```
 
+Socketen til daemonen kan bare leses av gruppen `halpid`. Pakken legger brukeren din til i gruppen, men medlemskapet gjelder først i nye påloggingsøkter. Hvis kommandoen ikke får kontakt, logg ut og inn igjen, eller bruk `sudo halpi status`.
+
 ## Installasjon av HALPI2-firmware
 
-Nå som kommandoen `halpi` er tilgjengelig, kan pakken `halpi2-firmware` installeres. Den flasher den nyeste firmwaren til HALPI2-kortet:
+Nå som kommandoen `halpi` er tilgjengelig, installer pakken `halpi2-firmware`, som inneholder firmware-filene under `/usr/share/halpi2-firmware/`:
 ```bash
 sudo apt install halpi2-firmware
 ```
 
-Firmwaren flashes automatisk når pakken installeres eller oppgraderes. Det kan slås av ved å sette `AUTO_FLASH_ON_INSTALL=no` i `/etc/halpid/firmware.conf`.
 
-Pakken installerer firmware-binærfilene under `/usr/share/halpi2-firmware/`. Hvis du vil flashe en bestemt versjon manuelt, gir du `halpi flash` stien til binærfilen:
+!!! warning "Flash firmwaren selv"
+    Pakken forsøker å flashe under installasjonen, men forsøket mislykkes stille i de nåværende utgivelsene ([`HALPI2-firmware` #40](https://github.com/hatlabs/HALPI2-firmware/issues/40)). Apt melder likevel om vellykket installasjon, så flash manuelt og kontroller resultatet.
+
+Flash firmwaren, og slå deretter av enheten. En omstart tar ikke den nye firmwaren i bruk:
 ```bash
-halpi flash /usr/share/halpi2-firmware/halpi2-rs-firmware_3.3.1.bin
+sudo halpi flash /usr/share/halpi2-firmware/halpi2-rs-firmware_*.bin
+sudo shutdown -h now
 ```
+
+Slå enheten på igjen og bekreft versjonen med `halpi status`. Ved en installasjon uten skjerm må du kunne nå strømbryteren før du kjører nedstengingen.
+
+[Programvareveiledningen](../user-guide/software.md#manuell-installasjon-av-firmware) beskriver den automatiske oppdateringsmekanismen og hvordan du slår den av.
 
 ## Oppsett av Signal K-server
 

--- a/docs/nl/software-development/ubuntu-installation.md
+++ b/docs/nl/software-development/ubuntu-installation.md
@@ -1,5 +1,5 @@
 ---
-translated_from: e096c9a0b090c6f3ced22a4d369daab4ad1fcadb
+translated_from: 9b2819d37e8c666f7908c658418aa61209985b55
 ---
 
 # Andere Debian-distributies gebruiken
@@ -52,6 +52,9 @@ exit
 
 De firmware voor de algemene onderdelen op het HALPI2-board configureert u door `/boot/firmware/config.txt` te bewerken en de volgende regels toe te voegen aan de sectie `[all]`:
 
+!!! danger "Controleer uw opstartapparaat voordat u dit plakt"
+    Het blok hieronder eindigt met `dtparam=sd=off`. Op een Compute Module 5 schakelt die regel de ingebouwde microSD-sleuf uit en, op een module met eMMC, ook de eMMC. Behoud de regel als u opstart vanaf NVMe, de standaardconfiguratie van de HALPI2. Verwijder hem als u opstart vanaf microSD of eMMC, anders start het apparaat na de volgende herstart niet meer op.
+
 ```text
 # --- HALPI2 / Raspberry Pi 5 IO setup ---
 
@@ -75,7 +78,10 @@ dtoverlay=uart4-pi5
 # controller over /dev/i2c-1.
 dtparam=i2c_arm=on
 
-# Disable the unused SD card interface.  It causes a long delay at shutdown.
+# Disable the SD interface.  Without this, shutdown stalls long enough that the
+# supercapacitors can run out before the controller powers the board down.
+# This also disables the onboard microSD slot and the eMMC on a CM5 that has
+# one, so omit the line if you boot from either.
 # See: https://github.com/raspberrypi/linux/issues/7014
 dtparam=sd=off
 ```
@@ -89,6 +95,18 @@ Dat doet u door een bestand `/etc/modules-load.d/i2c-dev.conf` aan te maken met:
 ```bash
 echo i2c-dev | sudo tee /etc/modules-load.d/i2c-dev.conf
 ```
+
+Start opnieuw op om de wijzigingen door te voeren en controleer daarna of de I2C-bus aanwezig is:
+
+```bash
+sudo reboot
+```
+
+```bash
+ls /dev/i2c-1
+```
+
+Bestaat `/dev/i2c-1` niet, loop dan de wijzigingen in `config.txt` na voordat u verdergaat. De `halpid`-daemon kan zonder die bus niet starten.
 
 ## CAN-bus (NMEA 2000) instellen
 
@@ -133,19 +151,28 @@ De HALPI2-daemon hoort nu te draaien en de opdracht `halpi` beschikbaar te zijn.
 halpi status
 ```
 
+De socket van de daemon is alleen leesbaar voor de groep `halpid`. Het pakket voegt uw gebruiker aan die groep toe, maar het lidmaatschap geldt pas in nieuwe aanmeldsessies. Kan de opdracht geen verbinding maken, meld u dan af en weer aan, of gebruik `sudo halpi status`.
+
 ## Firmware van de HALPI2 installeren
 
-Nu de opdracht `halpi` beschikbaar is, kunt u het pakket `halpi2-firmware` installeren, dat de nieuwste firmware naar het HALPI2-board flasht:
+Nu de opdracht `halpi` beschikbaar is, installeert u het pakket `halpi2-firmware`, dat de firmwarebestanden onder `/usr/share/halpi2-firmware/` levert:
 ```bash
 sudo apt install halpi2-firmware
 ```
 
-De firmware wordt automatisch geflasht wanneer het pakket wordt geïnstalleerd of bijgewerkt. U schakelt dit uit door `AUTO_FLASH_ON_INSTALL=no` in `/etc/halpid/firmware.conf` te zetten.
 
-Het pakket installeert de firmwarebestanden onder `/usr/share/halpi2-firmware/`. Wilt u een bepaalde versie handmatig flashen, geef `halpi flash` dan het pad naar het bestand:
+!!! warning "Flash de firmware zelf"
+    Het pakket probeert tijdens de installatie te flashen, maar die poging mislukt geruisloos in de huidige uitgaven ([`HALPI2-firmware` #40](https://github.com/hatlabs/HALPI2-firmware/issues/40)). Apt meldt toch succes, dus flash handmatig en controleer het resultaat.
+
+Flash de firmware en schakel het apparaat daarna uit. Een herstart neemt de nieuwe firmware niet in gebruik:
 ```bash
-halpi flash /usr/share/halpi2-firmware/halpi2-rs-firmware_3.3.1.bin
+sudo halpi flash /usr/share/halpi2-firmware/halpi2-rs-firmware_*.bin
+sudo shutdown -h now
 ```
+
+Schakel het apparaat weer in en controleer de versie met `halpi status`. Bij een installatie zonder scherm moet u de aan-uitschakelaar kunnen bereiken voordat u het afsluiten uitvoert.
+
+De [softwarehandleiding](../user-guide/software.md#firmware-handmatig-installeren) beschrijft het automatische updatemechanisme en hoe u dat uitschakelt.
 
 ## Signal K-server instellen
 

--- a/docs/nl/software-development/ubuntu-installation.md
+++ b/docs/nl/software-development/ubuntu-installation.md
@@ -1,5 +1,5 @@
 ---
-translated_from: 8c2d1560ad56e730c3fe6476cd5cf075b632b539
+translated_from: e096c9a0b090c6f3ced22a4d369daab4ad1fcadb
 ---
 
 # Andere Debian-distributies gebruiken
@@ -70,14 +70,26 @@ dtoverlay=mcp251xfd,spi0-1,interrupt=26,oscillator=40000000
 
 # Enable PL011 UART4.  Creates /dev/ttyAMA4 for NMEA 0183 communication.
 dtoverlay=uart4-pi5
+
+# Enable the ARM I2C bus.  The halpid daemon reaches the power management
+# controller over /dev/i2c-1.
+dtparam=i2c_arm=on
+
+# Disable the unused SD card interface.  It causes a long delay at shutdown.
+# See: https://github.com/raspberrypi/linux/issues/7014
+dtparam=sd=off
 ```
 
-Daarna moet de I2C-interface worden ingeschakeld, zodat de `halpid`-daemon in de gebruikersruimte met de hardware voor energiebeheer kan communiceren.
+!!! warning "I2C moet ingeschakeld zijn"
+    In Raspberry Pi OS staat `dtparam=i2c_arm=on` uitgecommentarieerd, en andere distributies doen dat mogelijk ook. Zonder die regel is er geen `/dev/i2c-1` en bereikt `halpid` de hardware voor energiebeheer niet.
+
+Daarnaast moet de kernelmodule `i2c-dev` bij het opstarten worden geladen, zodat de `halpid`-daemon in de gebruikersruimte de bus kan gebruiken.
 Dat doet u door een bestand `/etc/modules-load.d/i2c-dev.conf` aan te maken met:
 
 ```bash
-sudo echo i2c-dev > /etc/modules-load.d/i2c-dev.conf
+echo i2c-dev | sudo tee /etc/modules-load.d/i2c-dev.conf
 ```
+
 ## CAN-bus (NMEA 2000) instellen
 
 Met de volgende opdracht schakelt u de CAN-bus voor NMEA 2000-communicatie op de HALPI2 in:
@@ -125,12 +137,14 @@ halpi status
 
 Nu de opdracht `halpi` beschikbaar is, kunt u het pakket `halpi2-firmware` installeren, dat de nieuwste firmware naar het HALPI2-board flasht:
 ```bash
-apt install halpi2-firmware
+sudo apt install halpi2-firmware
 ```
 
-De firmware kan handmatig worden geflasht met:
+De firmware wordt automatisch geflasht wanneer het pakket wordt geïnstalleerd of bijgewerkt. U schakelt dit uit door `AUTO_FLASH_ON_INSTALL=no` in `/etc/halpid/firmware.conf` te zetten.
+
+Het pakket installeert de firmwarebestanden onder `/usr/share/halpi2-firmware/`. Wilt u een bepaalde versie handmatig flashen, geef `halpi flash` dan het pad naar het bestand:
 ```bash
-halpi flash /usr/share/halpi2/firmware/halpi2-rs-firmware_VERSION.bin
+halpi flash /usr/share/halpi2-firmware/halpi2-rs-firmware_3.3.1.bin
 ```
 
 ## Signal K-server instellen
@@ -171,7 +185,7 @@ Daar klikt u op de knop `+Add` en maakt u een verbinding aan met ten minste de v
                  ID: "HALPI2N0183"
    NMEA 0183 Source: Serial
         Serial Port: /dev/ttyAMA4
-          Baud Rate: 4800 | 34800
+          Baud Rate: 4800 | 38400
 ```
 
 Start opnieuw op en controleer op het dashboard of er gegevens binnenkomen.

--- a/docs/sv/software-development/ubuntu-installation.md
+++ b/docs/sv/software-development/ubuntu-installation.md
@@ -1,5 +1,5 @@
 ---
-translated_from: 8c2d1560ad56e730c3fe6476cd5cf075b632b539
+translated_from: e096c9a0b090c6f3ced22a4d369daab4ad1fcadb
 ---
 
 # Använda andra Debian-baserade distributioner
@@ -69,12 +69,23 @@ dtoverlay=mcp251xfd,spi0-1,interrupt=26,oscillator=40000000
 
 # Enable PL011 UART4.  Creates /dev/ttyAMA4 for NMEA 0183 communication.
 dtoverlay=uart4-pi5
+
+# Enable the ARM I2C bus.  The halpid daemon reaches the power management
+# controller over /dev/i2c-1.
+dtparam=i2c_arm=on
+
+# Disable the unused SD card interface.  It causes a long delay at shutdown.
+# See: https://github.com/raspberrypi/linux/issues/7014
+dtparam=sd=off
 ```
 
-Därefter måste I2C-gränssnittet aktiveras så att daemonen `halpid`, som körs i användarrymden, kan kommunicera med strömhanteringens hårdvara. Det gör du genom att skapa filen `/etc/modules-load.d/i2c-dev.conf`:
+!!! warning "I2C måste aktiveras"
+    I Raspberry Pi OS är `dtparam=i2c_arm=on` bortkommenterad, och andra distributioner kan göra likadant. Utan den finns ingen `/dev/i2c-1`, och `halpid` når inte strömhanteringens hårdvara.
+
+Kärnmodulen `i2c-dev` måste dessutom läsas in vid uppstart, så att daemonen `halpid`, som körs i användarrymden, kan använda bussen. Det gör du genom att skapa filen `/etc/modules-load.d/i2c-dev.conf`:
 
 ```bash
-sudo echo i2c-dev > /etc/modules-load.d/i2c-dev.conf
+echo i2c-dev | sudo tee /etc/modules-load.d/i2c-dev.conf
 ```
 
 ## Uppsättning av CAN-bussen (NMEA 2000)
@@ -125,13 +136,15 @@ halpi status
 Nu när kommandot `halpi` är tillgängligt kan du installera paketet `halpi2-firmware`, som flashar den senaste firmwaren till HALPI2-kortet:
 
 ```bash
-apt install halpi2-firmware
+sudo apt install halpi2-firmware
 ```
 
-Firmwaren kan också flashas manuellt:
+Firmwaren flashas automatiskt när paketet installeras eller uppgraderas. Du stänger av det genom att sätta `AUTO_FLASH_ON_INSTALL=no` i `/etc/halpid/firmware.conf`.
+
+Paketet installerar firmware-binärerna under `/usr/share/halpi2-firmware/`. Om du vill flasha en viss version manuellt anger du sökvägen till binären för `halpi flash`:
 
 ```bash
-halpi flash /usr/share/halpi2/firmware/halpi2-rs-firmware_VERSION.bin
+halpi flash /usr/share/halpi2-firmware/halpi2-rs-firmware_3.3.1.bin
 ```
 
 ## Uppsättning av Signal K-server
@@ -169,7 +182,7 @@ Starta om och kontrollera på instrumentpanelen om data kommer in.
                  ID: "HALPI2N0183"
    NMEA 0183 Source: Serial
         Serial Port: /dev/ttyAMA4
-          Baud Rate: 4800 | 34800
+          Baud Rate: 4800 | 38400
 ```
 
 Starta om och kontrollera på instrumentpanelen om data kommer in.

--- a/docs/sv/software-development/ubuntu-installation.md
+++ b/docs/sv/software-development/ubuntu-installation.md
@@ -1,5 +1,5 @@
 ---
-translated_from: e096c9a0b090c6f3ced22a4d369daab4ad1fcadb
+translated_from: 9b2819d37e8c666f7908c658418aa61209985b55
 ---
 
 # Använda andra Debian-baserade distributioner
@@ -51,6 +51,9 @@ exit
 
 Firmwaren för de gemensamma enheterna på HALPI2-kortet konfigureras genom att du redigerar `/boot/firmware/config.txt` och lägger till följande rader i avsnittet `[all]`:
 
+!!! danger "Kontrollera din startenhet innan du klistrar in"
+    Blocket nedan avslutas med `dtparam=sd=off`. På en Compute Module 5 stänger den raden av det inbyggda microSD-facket och, på en modul med eMMC, även eMMC:n. Behåll raden om du startar från NVMe, vilket är HALPI2:s standardkonfiguration. Ta bort den om du startar från microSD eller eMMC, annars startar enheten inte efter nästa omstart.
+
 ```text
 # --- HALPI2 / Raspberry Pi 5 IO setup ---
 
@@ -74,7 +77,10 @@ dtoverlay=uart4-pi5
 # controller over /dev/i2c-1.
 dtparam=i2c_arm=on
 
-# Disable the unused SD card interface.  It causes a long delay at shutdown.
+# Disable the SD interface.  Without this, shutdown stalls long enough that the
+# supercapacitors can run out before the controller powers the board down.
+# This also disables the onboard microSD slot and the eMMC on a CM5 that has
+# one, so omit the line if you boot from either.
 # See: https://github.com/raspberrypi/linux/issues/7014
 dtparam=sd=off
 ```
@@ -87,6 +93,18 @@ Kärnmodulen `i2c-dev` måste dessutom läsas in vid uppstart, så att daemonen 
 ```bash
 echo i2c-dev | sudo tee /etc/modules-load.d/i2c-dev.conf
 ```
+
+Starta om för att verkställa ändringarna och kontrollera sedan att I2C-bussen finns:
+
+```bash
+sudo reboot
+```
+
+```bash
+ls /dev/i2c-1
+```
+
+Om `/dev/i2c-1` saknas, gå tillbaka till ändringarna i `config.txt` innan du fortsätter. Daemonen `halpid` kan inte starta utan den.
 
 ## Uppsättning av CAN-bussen (NMEA 2000)
 
@@ -131,21 +149,29 @@ HALPI2-daemonen ska nu vara igång och kommandot `halpi` tillgängligt. Du kontr
 halpi status
 ```
 
+Daemonens socket är bara läsbar för gruppen `halpid`. Paketet lägger till din användare i gruppen, men medlemskapet gäller först i nya inloggningssessioner. Om kommandot inte kan ansluta, logga ut och in igen, eller använd `sudo halpi status`.
+
 ## Installation av HALPI2:s firmware
 
-Nu när kommandot `halpi` är tillgängligt kan du installera paketet `halpi2-firmware`, som flashar den senaste firmwaren till HALPI2-kortet:
+Nu när kommandot `halpi` är tillgängligt installerar du paketet `halpi2-firmware`, som innehåller firmware-filerna under `/usr/share/halpi2-firmware/`:
 
 ```bash
 sudo apt install halpi2-firmware
 ```
 
-Firmwaren flashas automatiskt när paketet installeras eller uppgraderas. Du stänger av det genom att sätta `AUTO_FLASH_ON_INSTALL=no` i `/etc/halpid/firmware.conf`.
 
-Paketet installerar firmware-binärerna under `/usr/share/halpi2-firmware/`. Om du vill flasha en viss version manuellt anger du sökvägen till binären för `halpi flash`:
+!!! warning "Flasha firmwaren själv"
+    Paketet försöker flasha under installationen, men försöket misslyckas tyst i nuvarande utgåvor ([`HALPI2-firmware` #40](https://github.com/hatlabs/HALPI2-firmware/issues/40)). Apt rapporterar ändå att allt gick bra, så flasha manuellt och kontrollera resultatet.
 
+Flasha firmwaren och stäng sedan av enheten. En omstart tar inte den nya firmwaren i bruk:
 ```bash
-halpi flash /usr/share/halpi2-firmware/halpi2-rs-firmware_3.3.1.bin
+sudo halpi flash /usr/share/halpi2-firmware/halpi2-rs-firmware_*.bin
+sudo shutdown -h now
 ```
+
+Slå på enheten igen och kontrollera versionen med `halpi status`. Vid en installation utan skärm behöver du komma åt strömbrytaren innan du kör avstängningen.
+
+[Programvaruguiden](../user-guide/software.md#installera-firmware-manuellt) beskriver den automatiska uppdateringsmekanismen och hur du stänger av den.
 
 ## Uppsättning av Signal K-server
 

--- a/solutions/translation/danish-glossary.md
+++ b/solutions/translation/danish-glossary.md
@@ -288,6 +288,7 @@ explanation. Only the Finnish glossary needs that warning.
 |:--------|:-------|:-----|
 | firmware | firmware | Not `fast programmel` — matches the sibling decision to keep the trade term |
 | daemon | dæmon | First mention: `dæmon (baggrundstjeneste)` |
+| kernel module | kernemodul | |
 | to flash | flashe | |
 | system image | systemimage | `et systemimage`, `systemimaget` — the trade says *image*, not *aftryk* |
 | operating system image | styresystemimage | |

--- a/solutions/translation/dutch-glossary.md
+++ b/solutions/translation/dutch-glossary.md
@@ -299,6 +299,7 @@ Two consequences worth stating:
 |:--------|:------|:-----|
 | firmware | firmware | Not *bedrijfsprogrammatuur* — the trade term, as in every sibling |
 | daemon | daemon | Not *achtergronddienst* |
+| kernel module | kernelmodule | |
 | to flash | flashen | Past participle *geflasht* |
 | system image / operating system image | systeemimage | |
 | container image | containerimage | Not *systeemimage* — that is a disk image |

--- a/solutions/translation/finnish-glossary.md
+++ b/solutions/translation/finnish-glossary.md
@@ -254,6 +254,7 @@ them.
 |:--------|:--------|:-----|
 | firmware | firmware | Not *laiteohjelmisto* — Hat Labs convention |
 | daemon | daemon | Not *taustaprosessi* — Hat Labs convention |
+| kernel module | ydinmoduuli | |
 | to flash | flashata | Established Hat Labs usage |
 | operating system image | levykuva | |
 | headless | ilman näyttöä | First mention: `ilman näyttöä (headless)` |

--- a/solutions/translation/french-glossary.md
+++ b/solutions/translation/french-glossary.md
@@ -213,6 +213,7 @@ does not have to.
 |:--------|:-------|:-----|
 | firmware | firmware | Not *micrologiciel* — matches the Finnish decision to keep the term the trade uses |
 | daemon | démon | Established in French Linux usage, unlike Finnish |
+| kernel module | module du noyau | |
 | to flash | flasher | |
 | operating system image | image système | |
 | headless | sans écran | First mention: `sans écran (headless)` |

--- a/solutions/translation/german-glossary.md
+++ b/solutions/translation/german-glossary.md
@@ -212,6 +212,7 @@ need that warning.
 |:--------|:-------|:-----|
 | firmware | Firmware | |
 | daemon | Daemon | |
+| kernel module | Kernelmodul | |
 | to flash | flashen | |
 | operating system image | Systemabbild | |
 | headless | ohne Bildschirm | First mention: `ohne Bildschirm (headless)` |

--- a/solutions/translation/italian-glossary.md
+++ b/solutions/translation/italian-glossary.md
@@ -299,6 +299,7 @@ English term is what is printed in the schematics the reader may open next.
 |:--------|:--------|:-----|
 | firmware | firmware | Invariable, masculine — matches the sibling decision to keep the trade term |
 | daemon | demone | Established in Italian Linux usage |
+| kernel module | modulo del kernel | |
 | flash (firmware) | flashare | `flashare il firmware dell'RP2040` |
 | flash (an image) | scrivere | Writing an OS image to the SSD: `scrivere l'immagine sull'unità SSD` |
 | system image | immagine di sistema | Also `immagine del sistema operativo` where the source spells it out |

--- a/solutions/translation/spanish-glossary.md
+++ b/solutions/translation/spanish-glossary.md
@@ -298,6 +298,7 @@ extra explanation. Only the Finnish glossary needs that warning.
 |:--------|:--------|:-----|
 | firmware | firmware | Not *microprogramación* — matches the sibling decision to keep the trade term |
 | daemon | demonio | Established in Spanish Linux usage, as in French |
+| kernel module | módulo del kernel | Not *módulo del núcleo* — matches integration.md |
 | to flash (firmware or an image) | grabar | Noun: *grabación*. Never *flashear* |
 | to flash (an LED) | parpadear | A machine translator renders both English senses the same way; these are different words in Spanish |
 | system image | imagen del sistema | |

--- a/solutions/translation/swedish-glossary.md
+++ b/solutions/translation/swedish-glossary.md
@@ -191,6 +191,7 @@ explanation. Only the Finnish glossary needs that warning.
 |:--------|:--------|:-----|
 | firmware | firmware | Not *fast programvara* — matches the sibling decision to keep the trade term |
 | daemon | daemon | |
+| kernel module | kärnmodul | |
 | to flash | flasha | |
 | operating system image | systemavbild | |
 | headless | utan skärm | First mention: `utan skärm (headless)` |


### PR DESCRIPTION
The manual install page had drifted from what a HALPI2 actually needs. Following it top to bottom left the reader with a `halpid` that could not reach the power management controller, and several commands that fail as written.

## What was wrong

`dtparam=i2c_arm=on` was missing. Raspberry Pi OS ships it commented out (`pi-gen/stage1/00-boot-files/files/config.txt`), so there was no `/dev/i2c-1` and the daemon had nothing to talk to. The page only loaded the `i2c-dev` module.

Four more defects on the same page:

- `sudo echo i2c-dev > /etc/modules-load.d/i2c-dev.conf` runs the redirect in the unprivileged shell and fails. Now `echo … | sudo tee …`.
- The manual flash path `/usr/share/halpi2/firmware/` does not exist. The package installs to `/usr/share/halpi2-firmware/`.
- `dtparam=sd=off` was missing. Without it shutdown can stall long enough to drain the supercapacitors before the controller powers the board down.
- The NMEA 0183 baud rate read `34800`.

## What review turned up

Reviewing the fix against the shipped packages and the hardware sources found three more, all of which changed the result:

**The package does not flash automatically.** Its postinst probes the board with `halpi get firmware_version`, and `halpi` has no `get` subcommand — `halpi/src/main.rs` defines `status`, `version`, `config`, `shutdown`, `usb`, `flash`. The probe fails on every machine, the postinst takes its fallback branch, and apt still reports success. Filed as hatlabs/HALPI2-firmware#40. The page now documents manual flashing as the real path, including the power-off the controller needs — a reboot does not apply new firmware.

**The reboot was in the wrong place.** `dtparam=i2c_arm=on` only takes effect after a restart, and the page's only reboot was the last line of the optional CAN section. A reader with no NMEA 2000 network went straight from editing `config.txt` to installing `halpid`, against a bus that did not exist. There is now an explicit reboot and an `ls /dev/i2c-1` check before the daemon is installed.

**`dtparam=sd=off` needs a precondition.** The Raspberry Pi kernel maps that parameter to `sdio1` on CM5 (`bcm2712-rpi-cm5.dtsi`), and the overlays README states it disables "the SD card (or eMMC on non-lite SKU of CM4/5)". HALPI2 carries a fitted microSD socket — J26 is `(dnp no)` in `SDCard.kicad_sch` and appears in `assembly-panel/bom.csv`. On NVMe, which is the standard configuration, the line is needed. On microSD or eMMC it makes the device unbootable. The line stays in the block, with a danger admonition before it so the reader checks their boot device first.

Smaller corrections from the same pass: the flash example no longer pins version 3.3.1 (it used a glob that cannot match `bootloader_*.bin`, which the package's own `head -n 1` selection does resolve to — noted on hatlabs/HALPI2-firmware#40); `halpi flash` gets the `sudo` the 0660 `root:halpid` socket requires; and the page notes that `halpi` needs a new login session before the `halpid` group applies.

## Translations

All nine carry the same changes. Code fences stay English per the `translate-page` skill, so all 16 blocks are byte-identical across the ten files. Each language keeps its own register — Spanish and Italian impersonal with infinitive steps, German Sie, French vouvoiement with U+00A0 before colons — and the cross-reference into `user-guide/software.md` uses each language's real translated anchor. `kernel module` is now recorded in eight glossaries, as the skill requires for a newly introduced term.

## Verification

`mkdocs build --strict`, `check_typography.py` (9 languages, 0 faults), `check_anchors.py` (9880 links resolve), `check_glossary.py` (all nine), and `translation_status.py` (20 current, 0 stale per language). The rendered HTML was checked to confirm the danger admonition appears in every language rather than trusting the source markdown. The one French `blackout` glossary finding predates this branch.

Two pre-existing bugs found during review are filed rather than fixed here: hatlabs/HALPI2-firmware#40 and #45.

A fly-by typo fix is included: "The following command with enable the CAN Bus" → "commands enable". The translations already rendered it correctly.
