### PR TITLE
Cap translation-status PR comment below GitHub's size limit

### DIFF
--- a/.github/workflows/translation-status.yml
+++ b/.github/workflows/translation-status.yml
@@ -58,6 +58,20 @@ jobs:
           # shellcheck disable=SC2086
           uv run python scripts/translation_status.py \
             --format markdown --diff --only-pages $pages > comment.md
+
+          # GitHub rejects comment bodies over 65536 characters (HTTP 422).
+          # Wide PRs produce reports far beyond that; fall back to the
+          # summary without diffs and point at the job summary instead.
+          if [ "$(wc -c < comment.md)" -gt 60000 ]; then
+            # shellcheck disable=SC2086
+            uv run python scripts/translation_status.py \
+              --format markdown --only-pages $pages > comment.md
+            {
+              echo ""
+              echo "_Diffs omitted: the full report exceeds GitHub's comment size limit._"
+              echo "_See the workflow run's job summary for the complete report._"
+            } >> comment.md
+          fi
           printf '\n<!-- translation-status -->\n' >> comment.md
 
           existing=$(gh api "repos/${{ github.repository }}/issues/$PR/comments" \


### PR DESCRIPTION
## Why

The Translation Status workflow posts its report as a PR comment. GitHub rejects issue-comment bodies over 65,536 characters with HTTP 422, and a PR touching many English pages produces a with-diff report far beyond that — 392 kB on the 10-page #47, which failed the check on every push.

## How

When `comment.md` exceeds 60,000 bytes, regenerate it without `--diff` (274 bytes for the same PR) and append a pointer to the job summary, which already carries the full report with diffs. Verified locally against the #47 page set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)